### PR TITLE
feat(pos): adds support for default customer selection from pos profile

### DIFF
--- a/pos/src/lib/customer-api.ts
+++ b/pos/src/lib/customer-api.ts
@@ -90,3 +90,27 @@ export async function searchCustomers(search: string, limit = 5) {
     throw error;
   }
 }
+
+export async function getCustomerByName(customerName: string): Promise<Customer | null> {
+  try {
+    if (!customerName) return null;
+    const customer = await db.getDoc(DOCTYPES.CUSTOMER, customerName);
+    return customer as Customer;
+  } catch (error) {
+    console.error(`Error fetching customer ${customerName}:`, error);
+    return null;
+  }
+}
+
+export async function getDefaultCustomerFromProfile(profile: any): Promise<Customer | null> {
+  try {
+    if (!profile?.customer) return null;
+
+    // Fetch full customer document
+    const customer = await getCustomerByName(profile.customer);
+    return customer;
+  } catch (error) {
+    console.error("Error fetching default customer:", error);
+    return null;
+  }
+}

--- a/pos/src/store/pos-store.ts
+++ b/pos/src/store/pos-store.ts
@@ -4,7 +4,7 @@ import { storage } from '../lib/storage';
 import { getRestaurantMenu, getAggregatorMenu, MenuItem as APIMenuItem } from '../lib/menu-api';
 import { getCurrencyInfo, PosProfileCombined, getCombinedPosProfile } from '../lib/pos-profile-api';
 import { getMenuCourses } from '../lib/menu-course-api';
-import { getCustomerGroups, getCustomerTerritories } from '../lib/customer-api';
+import { getCustomerGroups, getCustomerTerritories, getDefaultCustomerFromProfile } from '../lib/customer-api';
 import { DEFAULT_ORDER_TYPE, OrderType } from '../data/order-types';
 import { getTableOrder, TableOrder } from '../lib/order-api';
 import { getPaymentModes } from '../lib/payment-api';
@@ -93,6 +93,7 @@ interface POSState {
   selectedRoom: string | null;
   searchQuery: string;
   selectedCustomer: Customer | null;
+  defaultCustomer: Customer | null;
   selectedOrderType: OrderType;
   quickFilter: 'all' | 'special';
   selectedItem: MenuItem | null;
@@ -177,6 +178,7 @@ export const usePOSStore = create<POSStore>((set, get) => ({
   selectedRoom: null,
   searchQuery: '',
   selectedCustomer: null,
+  defaultCustomer: null,
   selectedOrderType: DEFAULT_ORDER_TYPE as OrderType,
   quickFilter: "all",
   selectedItem: null,
@@ -239,7 +241,9 @@ export const usePOSStore = create<POSStore>((set, get) => ({
         set({ 
           posProfile: profile, 
           profileLoading: false,
-          currency: profile.currency || 'INR'
+          currency: profile.currency || 'INR',
+          defaultCustomer: null,
+          selectedCustomer: null,
         });
         if (!storage.getItem('currencySymbol')) {
           await get().fetchCurrencySymbol();
@@ -251,10 +255,28 @@ export const usePOSStore = create<POSStore>((set, get) => ({
       const combinedProfile = await getCombinedPosProfile();
       
       sessionStorage.setItem('posProfile', JSON.stringify(combinedProfile));
+
+      let defaultCustomer = null;
+      if (combinedProfile?.customer) {
+        try {
+          defaultCustomer = await getDefaultCustomerFromProfile(combinedProfile);
+        } catch (err) {
+          console.error("Failed to fetch default customer:", err);
+        }
+      }
+
+      const customerData = defaultCustomer ? {
+          id: defaultCustomer.name,
+          name: defaultCustomer.customer_name,
+          phone: defaultCustomer.mobile_number,
+        } : null;
+
       set({ 
         posProfile: combinedProfile, 
         profileLoading: false,
-        currency: combinedProfile.currency || 'INR'
+        currency: combinedProfile.currency || 'INR',
+        defaultCustomer: customerData,
+        selectedCustomer: customerData,
       });
       
       if (!storage.getItem('currencySymbol')) {
@@ -662,10 +684,10 @@ export const usePOSStore = create<POSStore>((set, get) => ({
   },
 
   resetOrderState: () => {
-    const { fetchMenuItems } = get();
+    const { fetchMenuItems, defaultCustomer } = get();
     
     set({
-      selectedCustomer: null,
+      selectedCustomer: defaultCustomer || null,
       selectedTable: null,
       selectedRoom: null,
       selectedAggregator: null,


### PR DESCRIPTION
## Summary

This PR introduces support for automatically selecting a default customer when a POS profile is loaded.
It improves the overall order workflow by pre-filling the customer field, reducing manual input for cashiers and improving checkout efficiency.

## Changes Introduced

  - Added `defaultCustomer` state to POS store state
  - Implemented logic to **fetch and set** a default customer based on the POS profile
  - Ensures the **default customer is restored** on order state reset.

## Before

https://github.com/user-attachments/assets/b824dcee-f953-443b-bb58-913c4551adeb

## After

https://github.com/user-attachments/assets/0ac6f228-88b0-4bdf-ac78-2dbbc27c4e38
