### PR TITLE
fix(pos): reuse existing POS Invoice and improve QSR stock handling

### DIFF
--- a/ury/ury/doctype/ury_order/ury_order.py
+++ b/ury/ury/doctype/ury_order/ury_order.py
@@ -556,34 +556,37 @@ def cancel_order(invoice_id, reason):
 # Method for URY POS
 @frappe.whitelist()
 def make_invoice(customer, payments, cashier, pos_profile,owner, additionalDiscount=None, table=None, invoice=None):
-    order_type =  invoice_name = frappe.get_value("POS Invoice",invoice , "order_type")
-    invoice = get_order_invoice(table, invoice, order_type, "Payments")
+    # Always fetch existing draft invoice
+    invoice_doc = frappe.get_doc("POS Invoice", invoice)
 
     if table:
         restaurant = get_restaurant_and_menu_name(table)
-        invoice.restaurant = restaurant
+        invoice_doc.restaurant = restaurant
 
-    invoice.customer = customer
-    invoice.pos_profile = pos_profile
-    invoice.additional_discount_percentage=additionalDiscount
-    invoice.calculate_taxes_and_totals()
+    invoice_doc.customer = customer
+    invoice_doc.pos_profile = pos_profile
+    invoice_doc.additional_discount_percentage = additionalDiscount or 0
 
-    for pay in invoice.payments:
-        pay.delete(pay.mode_of_payment)
+    invoice_doc.calculate_taxes_and_totals()
+
+    invoice_doc.set("payments", [])
 
     for d in payments:
-        invoice.append(
-            "payments", dict(mode_of_payment=d["mode_of_payment"], amount=d["amount"])
-        )
+        invoice_doc.append("payments", {
+            "mode_of_payment": d["mode_of_payment"],
+            "amount": d["amount"]
+        })
 
-    invoice.owner = owner
-    invoice.save()
+    invoice_doc.owner = owner
+    invoice_doc.cashier = cashier
+
+    invoice_doc.save()
     try:
-        invoice.submit()
+        invoice_doc.submit()
     except Exception as e:
         frappe.throw(f"Error while settling order: {e}")
-    
-    
+
+    return invoice_doc.name
 
 # Cancel KOT Doc Creation
 def cancel_kot(invoice_id):


### PR DESCRIPTION
## Summary

This PR updates the `make_invoice()` method to **reuse the existing draft POS Invoice** instead of creating a new one and sets the foundation for better stock handling for QSR items.

For QSR (Quick Service Restaurant) Items, where products are made on-demand from raw materials. The previous implementation caused issues when validating stock availability, especially when multiple invoices were created for the same order.

## Key Changes
- **Reused existing draft invoice** instead of creating a new one during payment submission
- **Improved QSR workflow compatibility** by ensuring invoices and stock entries remain consistent.
- **Reset and re-appended payments** cleanly before submission to avoid mismatched payment allocations.

## Reason for Change

We were primarily solving **stock availability issues** for QSR items:

- In QSR workflows, finished goods are produced on-demand using raw materials.
- The previous implementation created duplicate **POS Invoices**, which led to:

  - Incorrectly reserved stock for finished products.
  - Mismatches between **Work Orders, Stock Entries**, and **POS Invoices.**

By reusing the existing draft invoice:

- Stock movements now remain **synchronized** with manufacturing and consumption.
- We avoid double-counting stock for the same order.
