### PR TITLE
update: Change default selected status to 'All Orders' in Orders slice

### DIFF
--- a/pos/src/store/slices/orders-slice.ts
+++ b/pos/src/store/slices/orders-slice.ts
@@ -71,7 +71,7 @@ export const createOrdersSlice: StateCreator<
     hasNextPage: false,
     itemsPerPage: ITEMS_PER_PAGE,
   },
-  selectedStatus: 'Draft',
+  selectedStatus: 'All Orders',
   selectedOrder: null,
   selectedOrderItems: [],
   selectedOrderTaxes: [],


### PR DESCRIPTION
Updated the initial state of the selectedStatus in the Orders slice from 'Draft' to 'All Orders' to provide a more comprehensive view of the orders available in the application.