### PR TITLE
fix(printing): fetch network printer settings correctly and enable CU…

### DIFF
--- a/ury/ury/api/ury_print.py
+++ b/ury/ury/api/ury_print.py
@@ -24,7 +24,7 @@ def network_printing(
     file_path=None,
 ):
     try:
-        print_settings = frappe("Network Printer Settings", printer_setting)
+        print_settings = frappe.get_doc("Network Printer Settings", printer_setting)
 
         try:
             import cups
@@ -53,7 +53,9 @@ def network_printing(
                 file_path = os.path.join(
                     "/", "tmp", f"frappe-pdf-{frappe.generate_hash()}.pdf"
                 )
-            output.write(open(file_path, "wb"))
+            
+            with open(file_path, "wb") as f:
+                output.write(f)
             conn.printFile(print_settings.printer_name, file_path, name, {})
 
             restaurant_table, invoice_printed, name = frappe.db.get_value(


### PR DESCRIPTION
…PS printing

- Replaced incorrect frappe() call with frappe.get_doc() to fetch printer settings
- Ensures correct server_ip, port, and printer_name are used for CUPS printing
- Logs detailed errors to assist with debugging network printing problems