### PR TITLE
feat(pos): override POSInvoice stock validation for QSR items

### DIFF
--- a/ury/hooks.py
+++ b/ury/hooks.py
@@ -109,23 +109,15 @@ website_route_rules = [
 # ---------------
 # Override standard doctype classes
 
-# override_doctype_class = {
-# 	"ToDo": "custom_app.overrides.CustomToDo"
-# }
+override_doctype_class = {
+	"POS Invoice": "ury.ury.hooks.ury_pos_invoice.URYPOSInvoice",
+}
 
 # Document Events
 # ---------------
 # Hook on document methods and events
 
 doc_events = {
-    "POS Invoice": {
-        "before_insert": "ury.ury.hooks.ury_pos_invoice.before_insert",
-        "validate": "ury.ury.hooks.ury_pos_invoice.validate",
-        "after_insert":"ury.ury.api.ury_kot_order_number.set_order_number",
-        "before_submit": "ury.ury.hooks.ury_pos_invoice.before_submit",
-        "on_cancel": "ury.ury.hooks.ury_pos_invoice.on_trash",
-        "on_trash": "ury.ury.hooks.ury_pos_invoice.on_trash",
-    },
     "POS Profile": {"validate": "ury.ury.hooks.ury_pos_profile.validate"},
     "Sales Invoice": {
         "before_insert": "ury.ury.hooks.ury_sales_invoice.before_insert",
@@ -354,7 +346,8 @@ fixtures = [
                     "POS Profile-custom_table_order_printer",
                     "POS Profile-custom_reprint_kot_format",
                     "Employee-payment_amount",
-                    "Employee-payment_type"
+                    "Employee-payment_type",
+                    "POS Profile-custom_require_invoice_printing_before_payment"
                 },
             ]
         ],

--- a/ury/ury/hooks/ury_pos_invoice.py
+++ b/ury/ury/hooks/ury_pos_invoice.py
@@ -1,209 +1,335 @@
-import frappe
 from datetime import datetime
-from frappe.utils import now_datetime, get_time,now
+
+import frappe
+from frappe import _
+from frappe.utils import flt, now
+
+from erpnext.accounts.doctype.pos_invoice.pos_invoice import POSInvoice, get_stock_availability
 
 
-def before_insert(doc, method):
-    pos_invoice_naming(doc, method)
-    order_type_update(doc, method)
-    restrict_existing_order(doc, method)
+class URYPOSInvoice(POSInvoice):
+
+	def before_insert(self):
+		self.pos_invoice_naming()
+		self.order_type_update()
+		self.restrict_existing_order()
 
 
-def validate(doc, method):
-    validate_invoice(doc, method)
-    validate_customer(doc, method)
-    validate_price_list(doc, method)
+	def validate(self):
+		super().validate()
+		self.validate_invoice()
+		self.validate_customer()
+		self.validate_price_list()
+
+		if self.taxes_and_charges and not len(self.get("taxes")):
+			self.set_taxes()
+
+		self.calculate_taxes_and_totals()
 
 
-def before_submit(doc, method):
-    calculate_and_set_times(doc, method)
-    validate_invoice_print(doc, method)
-    ro_reload_submit(doc, method)
+	def before_submit(self):
+		self.calculate_and_set_times()
+		self.validate_invoice_print()
+		self.ro_reload_submit()
 
 
-def on_trash(doc, method):
-    table_status_delete(doc, method)
+	def on_trash(self):
+		self.table_status_delete()
+
+	def validate_stock_availablility(self):
+		from erpnext.stock.stock_ledger import is_negative_stock_allowed
+		from erpnext.manufacturing.doctype.bom.bom import get_bom_items_as_dict
+		from erpnext.stock.utils import get_stock_balance
+
+		if self.is_return:
+			return
+
+		if self.docstatus.is_draft() and not frappe.db.get_value(
+			"POS Profile", self.pos_profile, "validate_stock_on_save"
+		):
+			return
+
+		# Fetch QSR item groups for this POS Profile
+		qsr_item_groups = self.get_qsr_item_groups(self.pos_profile)
+
+		missing_materials = []
+
+		for d in self.get("items"):
+			if d.serial_and_batch_bundle:
+				continue
+
+			item_group = frappe.db.get_value("Item", d.item_code, "item_group")
+
+			# If item belongs to QSR groups → validate raw materials
+			if item_group in qsr_item_groups:
+				# Find default BOM for the item
+				bom = frappe.db.get_value("BOM", {"item": d.item_code, "is_default": 1}, "name")
+				if not bom:
+					frappe.throw(
+						_("Row #{0}: No default BOM found for QSR Item {1}").format(
+							d.idx, frappe.bold(d.item_code)
+						)
+					)
+
+				# Get raw materials from BOM
+				bom_items = get_bom_items_as_dict(bom, company=self.company)
+				source_warehouse = frappe.db.get_value("POS Profile", self.pos_profile, "warehouse")
+
+				for rm_code, rm in bom_items.items():
+					required_qty = flt(rm["qty"]) * flt(d.stock_qty)
+					available_qty = get_stock_balance(
+						rm_code, source_warehouse, self.posting_date
+					)
+
+					if flt(available_qty) < required_qty:
+						missing_materials.append(
+							{
+								"row": d.idx,
+								"qsr_item": d.item_code,
+								"raw_material": rm_code,
+								"required": required_qty,
+								"available": available_qty,
+							}
+						)
+
+				continue  # Skip normal stock check for QSR items
+
+			# Normal stock validation for non-QSR items
+			if is_negative_stock_allowed(item_code=d.item_code):
+				continue
+
+			available_stock, is_stock_item = get_stock_availability(d.item_code, d.warehouse)
+			item_code, warehouse = frappe.bold(d.item_code), frappe.bold(d.warehouse)
+
+			if is_stock_item and flt(available_stock) <= 0:
+				frappe.throw(
+					_("Row #{}: Item Code {} is not available under warehouse {}.").format(
+						d.idx, item_code, warehouse
+					),
+					title=_("Item Unavailable"),
+				)
+			elif is_stock_item and flt(available_stock) < flt(d.stock_qty):
+				frappe.throw(
+					_("Row #{}: Stock quantity not enough for Item Code {} under warehouse {}.").format(
+						d.idx, item_code, warehouse
+					),
+					title=_("Item Unavailable"),
+				)
+
+		# After checking all items → show one combined error if any raw materials are missing
+		if missing_materials:
+			messages = []
+			for m in missing_materials:
+				messages.append(
+					_("Row #{0} | QSR Item: <b>{1}</b> → Raw Material: <b>{2}</b> "
+					"(Required: {3}, Available: {4})").format(
+						m["row"], m["qsr_item"], m["raw_material"],
+						m["required"], m["available"]
+					)
+				)
+			frappe.throw(
+				"<br>".join(messages),
+				title=_("Insufficient Raw Materials")
+			)
 
 
-def validate_invoice(doc, method):
-    if doc.waiter == None or doc.waiter == "":
-        doc.waiter = doc.modified_by
-    remove_items = frappe.db.get_value("POS Profile", doc.pos_profile, "remove_items")
-    
-    if doc.invoice_printed == 1 and remove_items == 0:
-        # Get the original items from db
-        original_doc = frappe.get_doc("POS Invoice", doc.name)
-        
-        # Create dictionaries to store both quantities and names
-        original_items = {
-            item.item_code: {"qty": item.qty, "name": item.item_name} 
-            for item in original_doc.items
-        }
-        current_items = {
-            item.item_code: {"qty": item.qty, "name": item.item_name} 
-            for item in doc.items
-        }
-          
-        # Check for removed items
-        removed_items = set(original_items.keys()) - set(current_items.keys())
-        
-        # Check for quantity reductions
-        reduced_qty_items = []
-        for item_code, item_data in original_items.items():
-            if (item_code in current_items and 
-                current_items[item_code]["qty"] < item_data["qty"]):
-                reduced_qty_items.append(
-                    f"{item_data['name']} (qty reduced from {item_data['qty']} "
-                    f"to {current_items[item_code]['qty']})"
-                )
-        
-        if removed_items or reduced_qty_items:
-            error_msg = []
-            if removed_items:
-                removed_item_names = [
-                    original_items[item_code]["name"] 
-                    for item_code in removed_items
-                ]
-                error_msg.append(f"Removed items: {', '.join(removed_item_names)}")
-            if reduced_qty_items:
-                error_msg.append(f"Modified quantities: {', '.join(reduced_qty_items)}")
-                
-            frappe.throw(
-                ("Cannot modify items after invoice is printed.\n{0}")
-                .format("\n".join(error_msg))
-            )
+	def validate_invoice(self):
+		if self.waiter == None or self.waiter == "":
+			self.waiter = self.modified_by
+		remove_items = frappe.db.get_value("POS Profile", self.pos_profile, "remove_items")
+		
+		if self.invoice_printed == 1 and remove_items == 0:
+			# Get the original items from db
+			original_doc = frappe.get_doc("POS Invoice", self.name)
+			
+			# Create dictionaries to store both quantities and names
+			original_items = {
+				item.item_code: {"qty": item.qty, "name": item.item_name} 
+				for item in original_doc.items
+			}
+			current_items = {
+				item.item_code: {"qty": item.qty, "name": item.item_name} 
+				for item in self.items
+			}
+			
+			# Check for removed items
+			removed_items = set(original_items.keys()) - set(current_items.keys())
+			
+			# Check for quantity reductions
+			reduced_qty_items = []
+			for item_code, item_data in original_items.items():
+				if (item_code in current_items and 
+					current_items[item_code]["qty"] < item_data["qty"]):
+					reduced_qty_items.append(
+						f"{item_data['name']} (qty reduced from {item_data['qty']} "
+						f"to {current_items[item_code]['qty']})"
+					)
+			
+			if removed_items or reduced_qty_items:
+				error_msg = []
+				if removed_items:
+					removed_item_names = [
+						original_items[item_code]["name"] 
+						for item_code in removed_items
+					]
+					error_msg.append(f"Removed items: {', '.join(removed_item_names)}")
+				if reduced_qty_items:
+					error_msg.append(f"Modified quantities: {', '.join(reduced_qty_items)}")
+					
+				frappe.throw(
+					("Cannot modify items after invoice is printed.\n{0}")
+					.format("\n".join(error_msg))
+				)
 
 
-def validate_customer(doc, method):
-    if doc.customer_name == None or doc.customer_name == "":
-        frappe.throw(
-            (" Failed to load data , Please Refresh the page ").format(
-                doc.customer_name
-            )
-        )
+	def validate_customer(self):
+		if self.customer_name == None or self.customer_name == "":
+			frappe.throw(
+				(" Failed to load data , Please Refresh the page ").format(
+					self.customer_name
+				)
+			)
 
 
-def calculate_and_set_times(doc, method):
-    doc.arrived_time = doc.creation
+	def calculate_and_set_times(self):
+		self.arrived_time = self.creation
 
-    current_time_str = now()
-    
-    current_time = datetime.strptime(current_time_str, "%Y-%m-%d %H:%M:%S.%f")
-    
-    time_difference = current_time - doc.creation
-    
-    total_seconds = int(time_difference.total_seconds())
-    hours, remainder = divmod(total_seconds, 3600)
-    minutes, seconds = divmod(remainder, 60)
-    
-    formatted_spend_time = f"{hours:02d}:{minutes:02d}:{seconds:02d}"
-    doc.total_spend_time = formatted_spend_time
-
-
-def validate_invoice_print(doc, method):
-    # Check if the invoice has been printed
-    invoice_printed = frappe.db.get_value("POS Invoice", doc.name, "invoice_printed")
-
-    # If the invoice is associated with a restaurant table and hasn't been printed
-    if doc.restaurant_table and invoice_printed == 0:
-        frappe.throw(
-            "Printing the invoice is mandatory before submitting. Please print the invoice."
-        )
+		current_time_str = now()
+		
+		current_time = datetime.strptime(current_time_str, "%Y-%m-%d %H:%M:%S.%f")
+		
+		time_difference = current_time - self.creation
+		
+		total_seconds = int(time_difference.total_seconds())
+		hours, remainder = divmod(total_seconds, 3600)
+		minutes, seconds = divmod(remainder, 60)
+		
+		formatted_spend_time = f"{hours:02d}:{minutes:02d}:{seconds:02d}"
+		self.total_spend_time = formatted_spend_time
 
 
-def table_status_delete(doc, method):
-    if doc.restaurant_table:
-        frappe.db.set_value(
-            "URY Table",
-            doc.restaurant_table,
-            {"occupied": 0, "latest_invoice_time": None},
-        )
+	def validate_invoice_print(self):
+		# Check if the invoice has been printed
+		invoice_printed = frappe.db.get_value("POS Invoice", self.name, "invoice_printed")
+
+		# If the invoice is associated with a restaurant table and hasn't been printed
+		if self.restaurant_table and invoice_printed == 0:
+			frappe.throw(
+				"Printing the invoice is mandatory before submitting. Please print the invoice."
+			)
 
 
-def pos_invoice_naming(doc, method):
-    pos_profile = frappe.get_doc("POS Profile", doc.pos_profile)
-    restaurant = pos_profile.restaurant
-
-    if not doc.restaurant_table:
-        doc.naming_series = frappe.db.get_value(
-            "URY Restaurant", restaurant, "invoice_series_prefix"
-        )
-        
-        if doc.order_type == "Aggregators":
-            doc.naming_series = frappe.db.get_value(
-                "URY Restaurant", restaurant, "aggregator_series_prefix"
-            )
-    
+	def table_status_delete(self):
+		if self.restaurant_table:
+			frappe.db.set_value(
+				"URY Table",
+				self.restaurant_table,
+				{"occupied": 0, "latest_invoice_time": None},
+			)
 
 
-def order_type_update(doc, method):
-    if doc.restaurant_table:
-        if not doc.order_type:
-            is_take_away = frappe.db.get_value(
-                "URY Table", doc.restaurant_table, "is_take_away"
-            )
-            if is_take_away == 1:
-                doc.order_type = "Take Away"
-            else:
-                doc.order_type = "Dine In"
-    
+	def pos_invoice_naming(self):
+		pos_profile = frappe.get_doc("POS Profile", self.pos_profile)
+		restaurant = pos_profile.restaurant
+
+		if not self.restaurant_table:
+			self.naming_series = frappe.db.get_value(
+				"URY Restaurant", restaurant, "invoice_series_prefix"
+			)
+			
+			if self.order_type == "Aggregators":
+				self.naming_series = frappe.db.get_value(
+					"URY Restaurant", restaurant, "aggregator_series_prefix"
+				)
+	
 
 
-# reload restaurant order page if submitted invoice is open there
-def ro_reload_submit(doc, method):
-    frappe.publish_realtime("reload_ro", {"name": doc.name})
+	def order_type_update(self):
+		if self.restaurant_table:
+			if not self.order_type:
+				is_take_away = frappe.db.get_value(
+					"URY Table", self.restaurant_table, "is_take_away"
+				)
+				if is_take_away == 1:
+					self.order_type = "Take Away"
+				else:
+					self.order_type = "Dine In"
+	
 
 
-def validate_price_list(doc, method):
-        
-    if doc.restaurant:
-        
-        if doc.restaurant_table:
-            room = frappe.db.get_value("URY Table", doc.restaurant_table, "restaurant_room")
-            menu_name = (
-                frappe.db.get_value("URY Restaurant", doc.restaurant, "active_menu")
-                if not frappe.db.get_value(
-                    "URY Restaurant", doc.restaurant, "room_wise_menu"
-                )
-                else frappe.db.get_value(
-                    "Menu for Room", {"parent": doc.restaurant, "room": room}, "menu"
-                )
-            )
+	# reload restaurant order page if submitted invoice is open there
+	def ro_reload_submit(self):
+		frappe.publish_realtime("reload_ro", {"name": self.name})
 
-            doc.selling_price_list = frappe.db.get_value(
-                "Price List", dict(restaurant_menu=menu_name, enabled=1)
-            )
-        
-        if doc.order_type == "Aggregators":
-            price_list = frappe.db.get_value("Aggregator Settings",
-                {"customer": doc.customer, "parent": doc.branch, "parenttype": "Branch"},
-                "price_list",
-                )
-            
-            if not price_list:
-                frappe.throw(f"Price list for customer {doc.customer} in branch {doc.branch} not found in Aggregator Settings.")
-                
-            doc.selling_price_list = price_list
-            
-        else:
-            menu_name = frappe.db.get_value("URY Restaurant", doc.restaurant, "active_menu") 
 
-            doc.selling_price_list = frappe.db.get_value(
-                "Price List", dict(restaurant_menu=menu_name, enabled=1)
-            )
-            
+	def validate_price_list(self):
+			
+		if self.restaurant:
+			
+			if self.restaurant_table:
+				room = frappe.db.get_value("URY Table", self.restaurant_table, "restaurant_room")
+				menu_name = (
+					frappe.db.get_value("URY Restaurant", self.restaurant, "active_menu")
+					if not frappe.db.get_value(
+						"URY Restaurant", self.restaurant, "room_wise_menu"
+					)
+					else frappe.db.get_value(
+						"Menu for Room", {"parent": self.restaurant, "room": room}, "menu"
+					)
+				)
 
-def restrict_existing_order(doc, event):
-    if doc.restaurant_table:
-        invoice_exist = frappe.db.exists(
-            "POS Invoice",
-            {
-                "restaurant_table": doc.restaurant_table,
-                "docstatus": 0,
-                "invoice_printed": 0,
-            },
-        )
-        if invoice_exist:
-            frappe.throw(
-                ("Table {0} has an existing invoice").format(doc.restaurant_table)
-            )
+				self.selling_price_list = frappe.db.get_value(
+					"Price List", dict(restaurant_menu=menu_name, enabled=1)
+				)
+			
+			if self.order_type == "Aggregators":
+				price_list = frappe.db.get_value("Aggregator Settings",
+					{"customer": self.customer, "parent": self.branch, "parenttype": "Branch"},
+					"price_list",
+					)
+				
+				if not price_list:
+					frappe.throw(f"Price list for customer {self.customer} in branch {self.branch} not found in Aggregator Settings.")
+					
+				self.selling_price_list = price_list
+				
+			else:
+				menu_name = frappe.db.get_value("URY Restaurant", self.restaurant, "active_menu") 
+
+				self.selling_price_list = frappe.db.get_value(
+					"Price List", dict(restaurant_menu=menu_name, enabled=1)
+				)
+			
+
+	def restrict_existing_order(self):
+		if self.restaurant_table:
+			invoice_exist = frappe.db.exists(
+				"POS Invoice",
+				{
+					"restaurant_table": self.restaurant_table,
+					"docstatus": 0,
+					"invoice_printed": 0,
+				},
+			)
+			if invoice_exist:
+				frappe.throw(
+					("Table {0} has an existing invoice").format(self.restaurant_table)
+				)
+
+	@staticmethod
+	def get_qsr_item_groups(pos_profile):
+		"""
+		Get all item groups linked to the URY Production Unit assigned to this POS Profile.
+		"""
+		production_unit = frappe.db.get_value(
+			"URY Production Unit", {"pos_profile", pos_profile}, "name"
+		)
+
+		if not production_unit:
+			return []
+		
+		return frappe.get_all(
+			"URY Production Item Groups",
+			filters={"parent": production_unit},
+			pluck="item_group"
+		)


### PR DESCRIPTION
### Summary
- Extended `POSInvoice` with a custom subclass to support QSR (make-to-order) items.
- Overrode `validate_stock_availability` to validate **raw material availability** from BOM instead of finished item stock.
- Currently checking availalbility from the warehouse in the POS Profile

### Details
- Added check for QSR item groups defined in `URY Production Unit`.
- For QSR items:
  - Fetches the default BOM and calculates required raw material quantities.
  - Resolves warehouse priority as:
    1. POS Profile `source_warehouse`

  - Throws a combined error message if any raw materials are short, showing required vs available qty and warehouse.
- For non-QSR items:
  - Preserves standard stock availability checks.

### Impact
- Restaurants with multiple branches (one company, many warehouses) can now validate raw material availability per branch correctly.
- Prevents POS from confirming orders that cannot be fulfilled due to insufficient raw material stock.