### PR TITLE
Fix: Correctly Display Waiter Instead of Cashier in Orders

### DIFF
--- a/pos/src/pages/Orders.tsx
+++ b/pos/src/pages/Orders.tsx
@@ -320,7 +320,7 @@ export default function Orders() {
 
                       <div className='flex items-center gap-2 text-xs text-gray-500'>
                         <UserCheck className='w-3.5 h-3.5' />
-                        <span>{order.cashier_name || order.cashier}</span>
+                        <span>{order.waiter_name}</span>
                       </div>
 
                       {/* Total - pushed to bottom like MenuCard */}

--- a/pos/src/store/slices/orders-slice.ts
+++ b/pos/src/store/slices/orders-slice.ts
@@ -10,7 +10,7 @@ export interface POSInvoice {
   grand_total: number;
   restaurant_table: string | null;
   cashier: string;
-  cashier_name: string;
+  waiter_name: string;
   waiter: string;
   net_total: number;
   posting_time: string;

--- a/ury/ury_pos/api.py
+++ b/ury/ury_pos/api.py
@@ -744,11 +744,11 @@ def getAllOrders(limit, limit_start):
         """
         SELECT 
             pi.name, pi.invoice_printed, pi.grand_total, pi.restaurant_table, 
-            pi.cashier, u.full_name as cashier_name, pi.waiter, pi.net_total, pi.posting_time, 
+            pi.cashier, pi.waiter, u.full_name as waiter_name, pi.net_total, pi.posting_time, 
             pi.total_taxes_and_charges, pi.customer, pi.status, pi.mobile_number, 
             pi.posting_date, pi.rounded_total, pi.order_type 
         FROM `tabPOS Invoice` pi
-        LEFT JOIN `tabUser` u ON pi.cashier = u.email
+        LEFT JOIN `tabUser` u ON pi.waiter = u.email
         WHERE pi.branch = %s AND pi.status = 'Draft'
         AND (
             pi.invoice_printed = 1 


### PR DESCRIPTION
This pull request addresses a bug in the orders feature where the cashier's name was being displayed instead of the waiter's. The changes ensure that all order data and displays correctly reflect the assigned waiter.

## Key Changes:

* **Backend Data Retrieval:** The `getAllOrders` query in `api.py` was updated to join on the `waiter` field (instead of `cashier`) and select the full name as `waiter_name`. This ensures that the correct user data is fetched from the database.
* **Frontend Data Model:** The `POSInvoice` interface was updated to use `waiter_name` instead of `cashier_name` to store the correct user information.
* **UI Correction:** The orders page now displays the **`waiter_name`** in the user information section, providing an accurate view of who handled the order.

### Before
<img width="1531" height="263" alt="previous screenshot of orders in pos royal oven" src="https://github.com/user-attachments/assets/cab662cf-6513-4a20-8da2-c6bb63823f1f" />

### After

<img width="1531" height="263" alt="Royal oven screenshot pos orders" src="https://github.com/user-attachments/assets/eb63ed24-dbb0-4757-997d-67d528fc594e" />
