### PR TITLE
feat: add hybrid stock validation for QSR items in POS Invoice

### DIFF
--- a/ury/ury/hooks/ury_pos_invoice.py
+++ b/ury/ury/hooks/ury_pos_invoice.py
@@ -63,34 +63,35 @@ class URYPOSInvoice(POSInvoice):
 			# If item belongs to QSR groups → validate raw materials
 			if item_group in qsr_item_groups:
 				# Find default BOM for the item
-				bom = frappe.db.get_value("BOM", {"item": d.item_code, "is_default": 1}, "name")
-				if not bom:
-					frappe.throw(
-						_("Row #{0}: No default BOM found for QSR Item {1}").format(
-							d.idx, frappe.bold(d.item_code)
+				if self.docstatus.is_draft():
+					bom = frappe.db.get_value("BOM", {"item": d.item_code, "is_default": 1}, "name")
+					if not bom:
+						frappe.throw(
+							_("Row #{0}: No default BOM found for QSR Item {1}").format(
+								d.idx, frappe.bold(d.item_code)
+							)
 						)
-					)
 
-				# Get raw materials from BOM
-				bom_items = get_bom_items_as_dict(bom, company=self.company)
-				source_warehouse = frappe.db.get_value("POS Profile", self.pos_profile, "warehouse")
+					# Get raw materials from BOM
+					bom_items = get_bom_items_as_dict(bom, company=self.company)
+					source_warehouse = frappe.db.get_value("POS Profile", self.pos_profile, "warehouse")
 
-				for rm_code, rm in bom_items.items():
-					required_qty = flt(rm["qty"]) * flt(d.stock_qty)
-					available_qty = get_stock_balance(
-						rm_code, source_warehouse, self.posting_date
-					)
-
-					if flt(available_qty) < required_qty:
-						missing_materials.append(
-							{
-								"row": d.idx,
-								"qsr_item": d.item_code,
-								"raw_material": rm_code,
-								"required": required_qty,
-								"available": available_qty,
-							}
+					for rm_code, rm in bom_items.items():
+						required_qty = flt(rm["qty"]) * flt(d.stock_qty)
+						available_qty = get_stock_balance(
+							rm_code, source_warehouse, self.posting_date
 						)
+
+						if flt(available_qty) < required_qty:
+							missing_materials.append(
+								{
+									"row": d.idx,
+									"qsr_item": d.item_code,
+									"raw_material": rm_code,
+									"required": required_qty,
+									"available": available_qty,
+								}
+							)
 
 				continue  # Skip normal stock check for QSR items
 


### PR DESCRIPTION
- Enhanced `validate_stock_availablility` to handle QSR items differently
- Draft stage:
  - Non-QSR items → use standard ERPNext stock checks
  - QSR items → validate raw materials based on default BOM
- Submit stage:
  - Non-QSR items → continue normal stock checks
  - QSR items → skip raw material validation, since stock is already consumed via Work Orders/Stock Entries
- Prevents double validation errors when receiving payment for QSR orders
- Ensures raw materials are validated only at order placement while keeping submission smooth