### PR TITLE
fix: set warehouse on POS Invoice items from POS Profile

### DIFF
--- a/ury/ury/doctype/ury_order/ury_order.py
+++ b/ury/ury/doctype/ury_order/ury_order.py
@@ -249,6 +249,7 @@ def sync_order(
     invoice.items = []
     
     menu = frappe.db.get_value("URY Menu", {"branch": invoice.branch}, "name")
+    warehouse = frappe.db.get_value("POS Profile", pos_profile, "warehouse")
    
     for d in items:
         
@@ -278,6 +279,7 @@ def sync_order(
                     cost_center = frappe.db.get_value(
                         "POS Profile", pos_profile, "cost_center"
                         ),
+                    warehouse=warehouse,
                 ),
             )
 


### PR DESCRIPTION
- Ensure each POS Invoice item inherits the warehouse defined in the POS Profile
- Prevents stock validation errors caused by missing or incorrect `d.warehouse`
- Keeps QSR raw material checks and normal stock checks aligned with actual stock location