### PR TITLE
fix: correct time calculation in validate_invoice_print method

### DIFF
--- a/ury/ury/hooks/ury_pos_invoice.py
+++ b/ury/ury/hooks/ury_pos_invoice.py
@@ -199,11 +199,17 @@ class URYPOSInvoice(POSInvoice):
 		self.arrived_time = self.creation
 
 		current_time_str = now()
+		creation_time = None
 		
 		current_time = datetime.strptime(current_time_str, "%Y-%m-%d %H:%M:%S.%f")
 		
-		time_difference = current_time - self.creation
-		
+		if isinstance(self.creation, str):
+			creation_time = datetime.strptime(self.creation, "%Y-%m-%d %H:%M:%S.%f")
+		else:
+			creation_time = self.creation
+
+		time_difference = current_time - creation_time
+
 		total_seconds = int(time_difference.total_seconds())
 		hours, remainder = divmod(total_seconds, 3600)
 		minutes, seconds = divmod(remainder, 60)


### PR DESCRIPTION
This pull request updates the `calculate_and_set_times` method in `ury/ury/hooks/ury_pos_invoice.py` to improve how the creation time is handled. The main change ensures that `self.creation` is correctly parsed as a `datetime` object if it is a string, preventing potential errors when calculating time differences.

Time handling improvements:

* Updated `calculate_and_set_times` to check if `self.creation` is a string and parse it to a `datetime` object if necessary, ensuring robust time calculations.