### PR TITLE
fix: correct item code and warehouse assignment in stock availability check

### DIFF
--- a/pos/src/components/PaymentDialog.tsx
+++ b/pos/src/components/PaymentDialog.tsx
@@ -1,10 +1,9 @@
-import React, { useState, useEffect } from 'react';
-import { X, Percent, Coins } from 'lucide-react';
-import { usePOSStore } from '../store/pos-store';
-import { cn, formatCurrency } from '../lib/utils';
-import { Button, Input, Dialog, DialogContent } from './ui';
-import { call } from '../lib/frappe-sdk';
-
+import React, { useState, useEffect } from "react";
+import { X, Percent, Coins } from "lucide-react";
+import { usePOSStore } from "../store/pos-store";
+import { cn, formatCurrency } from "../lib/utils";
+import { Button, Input, Dialog, DialogContent } from "./ui";
+import { call } from "../lib/frappe-sdk";
 
 interface PaymentDialogProps {
   onClose: () => void;
@@ -31,15 +30,21 @@ const PaymentDialog: React.FC<PaymentDialogProps> = ({
   cashier,
   owner,
   fetchOrders,
-  clearSelectedOrder
+  clearSelectedOrder,
 }) => {
-  const { paymentModes, fetchPaymentModes, posProfile: storePosProfile } = usePOSStore();
+  const {
+    paymentModes,
+    fetchPaymentModes,
+    posProfile: storePosProfile,
+  } = usePOSStore();
   const [isProcessing, setIsProcessing] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [discountType] = useState<'percentage'>('percentage'); // Only percentage now
-  const [discountValue, setDiscountValue] = useState<string>('');
+  const [discountType] = useState<"percentage">("percentage"); // Only percentage now
+  const [discountValue, setDiscountValue] = useState<string>("");
   const [appliedDiscount, setAppliedDiscount] = useState<number>(0);
-  const [paymentInputs, setPaymentInputs] = useState<{ [mode: string]: string }>({});
+  const [paymentInputs, setPaymentInputs] = useState<{
+    [mode: string]: string;
+  }>({});
 
   useEffect(() => {
     fetchPaymentModes();
@@ -48,8 +53,8 @@ const PaymentDialog: React.FC<PaymentDialogProps> = ({
   // Calculate split payment total
   const payments = paymentModes
     .map((mode: any) => {
-      const id = typeof mode === 'string' ? mode : mode.id;
-      const amount = parseFloat(paymentInputs[id] || '');
+      const id = typeof mode === "string" ? mode : mode.id;
+      const amount = parseFloat(paymentInputs[id] || "");
       return amount > 0 ? { mode_of_payment: id, amount } : null;
     })
     .filter(Boolean);
@@ -58,11 +63,11 @@ const PaymentDialog: React.FC<PaymentDialogProps> = ({
   const handleApplyDiscount = () => {
     const value = parseFloat(discountValue);
     if (isNaN(value) || value <= 0) {
-      setError('Please enter a valid discount value');
+      setError("Please enter a valid discount value");
       return;
     }
     if (value > 100) {
-      setError('Percentage discount cannot exceed 100%');
+      setError("Percentage discount cannot exceed 100%");
       return;
     }
     const calculatedDiscount = (grandTotal * value) / 100;
@@ -78,7 +83,10 @@ const PaymentDialog: React.FC<PaymentDialogProps> = ({
   const totalDiscount = appliedDiscount;
   const discountedTotal = Math.max(0, subtotal - totalDiscount);
   // If discount is applied, round up; else, round normally
-  const finalTotal = appliedDiscount > 0 ? Math.ceil(discountedTotal) : Math.round(discountedTotal);
+  const finalTotal =
+    appliedDiscount > 0
+      ? Math.ceil(discountedTotal)
+      : Math.round(discountedTotal);
   const finalAdjustment = finalTotal - discountedTotal;
   const roundedFinalAdjustment = Math.round(finalAdjustment * 100) / 100;
   const showFinalAdjustment = Math.abs(roundedFinalAdjustment) > 0.001;
@@ -93,11 +101,11 @@ const PaymentDialog: React.FC<PaymentDialogProps> = ({
 
   // Handler for input focus to auto-fill remaining balance
   const handlePaymentInputFocus = (id: string) => {
-    setPaymentInputs(inputs => {
+    setPaymentInputs((inputs) => {
       // Only auto-fill if the field is empty or zero
       if (!inputs[id] || parseFloat(inputs[id]) === 0) {
         const remaining = getRemainingBalance(id);
-        return { ...inputs, [id]: remaining > 0 ? String(remaining) : '' };
+        return { ...inputs, [id]: remaining > 0 ? String(remaining) : "" };
       }
       return inputs;
     });
@@ -107,7 +115,7 @@ const PaymentDialog: React.FC<PaymentDialogProps> = ({
     setIsProcessing(true);
     setError(null);
     try {
-      await call.post('ury.ury.doctype.ury_order.ury_order.make_invoice', {
+      await call.post("ury.ury.doctype.ury_order.ury_order.make_invoice", {
         additionalDiscount: discountValue ? parseInt(discountValue) : null,
         cashier,
         customer,
@@ -117,15 +125,78 @@ const PaymentDialog: React.FC<PaymentDialogProps> = ({
         pos_profile: posProfile,
         table,
       });
-      // Show toast and reload orders (assume showToast and reload available globally)
-      if (typeof window !== 'undefined' && (window as any).showToast) {
-        (window as any).showToast.success('Payment successful');
+
+      if (typeof window !== "undefined" && (window as any).showToast) {
+        (window as any).showToast.success("Payment successful");
       }
       onClose();
       clearSelectedOrder();
       await fetchOrders();
-    } catch (err) {
-      setError((err as Error).message);
+    } catch (err: any) {
+      console.error("Error processing payment:", err);
+
+      // Enhanced error message extraction
+      let errorMessage = "Payment processing failed";
+
+      // Strip HTML tags helper function
+      const stripHtml = (html: string) => {
+        const tmp = document.createElement("div");
+        tmp.innerHTML = html;
+        return tmp.textContent || tmp.innerText || "";
+      };
+
+      if (err && typeof err === "object") {
+        // Handle Frappe API errors
+        if (
+          "_server_messages" in err &&
+          typeof err._server_messages === "string"
+        ) {
+          try {
+            const messages = JSON.parse(err._server_messages);
+            const messageObj = JSON.parse(messages[0]);
+            errorMessage = stripHtml(
+              messageObj.message || messageObj.description || errorMessage
+            );
+          } catch {
+            errorMessage = "Server error occurred during payment processing";
+          }
+        } else if ("message" in err && typeof err.message === "string") {
+          errorMessage = stripHtml(err.message);
+        } else if ("exc" in err && typeof err.exc === "string") {
+          // Handle Frappe exception format
+          if (err.exc.includes("Stock quantity not enough")) {
+            errorMessage = stripHtml(err.exc);
+          } else if (err.exc.includes("Raw Material")) {
+            errorMessage = stripHtml(err.exc);
+          } else if (err.exc.includes("PermissionError")) {
+            errorMessage = "You don't have permission to process this payment";
+          } else {
+            errorMessage = stripHtml(err.exc);
+          }
+        } else if ("error" in err) {
+          errorMessage = stripHtml(String(err.error));
+        }
+      } else if (err instanceof Error) {
+        errorMessage = stripHtml(err.message);
+      } else if (typeof err === "string") {
+        errorMessage = stripHtml(err);
+      }
+
+      // Set both local error state and show toast with longer duration
+      setError(errorMessage);
+
+      if (typeof window !== "undefined" && (window as any).showToast) {
+        // Show toast with longer duration for critical errors
+        if (
+          errorMessage.includes("Stock quantity not enough") ||
+          errorMessage.includes("Raw Material") ||
+          errorMessage.includes("not available")
+        ) {
+          (window as any).showToast.error(errorMessage, { duration: 12000 });
+        } else {
+          (window as any).showToast.error(errorMessage, { duration: 8000 });
+        }
+      }
     } finally {
       setIsProcessing(false);
     }
@@ -133,41 +204,45 @@ const PaymentDialog: React.FC<PaymentDialogProps> = ({
 
   return (
     <Dialog open={true} onOpenChange={onClose}>
-      <DialogContent variant="xlarge" className="bg-white w-full max-w-4xl max-h-[90vh] flex flex-col md:flex-row p-0" showCloseButton={false}>
+      <DialogContent
+        variant='xlarge'
+        className='bg-white w-full max-w-4xl max-h-[90vh] flex flex-col md:flex-row p-0'
+        showCloseButton={false}
+      >
         {/* Left Column - Discount and Payment Mode */}
-        <div className="md:w-1/2 p-6 border-b md:border-b-0 md:border-r border-gray-200 overflow-y-auto">
-          <div className="flex justify-between items-center mb-6">
-            <h2 className="text-2xl font-bold text-gray-900">Payment</h2>
+        <div className='md:w-1/2 p-6 border-b md:border-b-0 md:border-r border-gray-200 overflow-y-auto'>
+          <div className='flex justify-between items-center mb-6'>
+            <h2 className='text-2xl font-bold text-gray-900'>Payment</h2>
             <Button
               onClick={onClose}
-              variant="ghost"
-              size="icon"
-              className="p-2"
+              variant='ghost'
+              size='icon'
+              className='p-2'
             >
-              <X className="w-5 h-5" />
+              <X className='w-5 h-5' />
             </Button>
           </div>
 
           {/* Discount Section (conditional) */}
           {storePosProfile?.enable_discount === 1 && (
-            <div className="space-y-4 mb-6">
-              <h3 className="text-lg font-semibold flex items-center gap-2">
-                <Percent className="w-5 h-5" />
+            <div className='space-y-4 mb-6'>
+              <h3 className='text-lg font-semibold flex items-center gap-2'>
+                <Percent className='w-5 h-5' />
                 Apply Discount
               </h3>
-              <div className="flex gap-2">
+              <div className='flex gap-2'>
                 <Input
-                  type="number"
+                  type='number'
                   value={discountValue}
                   onChange={(e) => setDiscountValue(e.target.value)}
-                  placeholder={'Enter %'}
-                  size="sm"
-                  className="flex-1"
+                  placeholder={"Enter %"}
+                  size='sm'
+                  className='flex-1'
                 />
                 <Button
                   onClick={handleApplyDiscount}
-                  variant="default"
-                  size="sm"
+                  variant='default'
+                  size='sm'
                 >
                   Apply
                 </Button>
@@ -176,38 +251,51 @@ const PaymentDialog: React.FC<PaymentDialogProps> = ({
           )}
 
           {/* Payment Methods Section - Split Payment */}
-          <div className="space-y-4 mb-6">
-            <h3 className="text-lg font-semibold">Payment Methods</h3>
-            <div className="grid grid-cols-1 gap-3">
+          <div className='space-y-4 mb-6'>
+            <h3 className='text-lg font-semibold'>Payment Methods</h3>
+            <div className='grid grid-cols-1 gap-3'>
               {paymentModes.map((mode: any) => {
-                const id = typeof mode === 'string' ? mode : mode.id;
+                const id = typeof mode === "string" ? mode : mode.id;
                 return (
-                  <div key={id} className="flex items-center gap-3">
-                    <span className="w-24 font-medium">{typeof mode === 'string' ? mode : mode.name}</span>
+                  <div key={id} className='flex items-center gap-3'>
+                    <span className='w-24 font-medium'>
+                      {typeof mode === "string" ? mode : mode.name}
+                    </span>
                     <Input
-                      type="number"
-                      min="0"
-                      step="0.01"
-                      value={paymentInputs[id] || ''}
-                      onChange={e => setPaymentInputs(inputs => ({ ...inputs, [id]: e.target.value }))}
+                      type='number'
+                      min='0'
+                      step='0.01'
+                      value={paymentInputs[id] || ""}
+                      onChange={(e) =>
+                        setPaymentInputs((inputs) => ({
+                          ...inputs,
+                          [id]: e.target.value,
+                        }))
+                      }
                       onFocus={() => handlePaymentInputFocus(id)}
-                      placeholder="Amount"
-                      className="flex-1"
-                      size="sm"
+                      placeholder='Amount'
+                      className='flex-1'
+                      size='sm'
                       disabled={isProcessing}
                     />
                   </div>
                 );
               })}
             </div>
-            <div className="flex justify-between mt-2 text-sm">
-              <span className="font-medium">Total Entered</span>
-              <span className={'text-green-600 font-semibold flex items-center gap-1'}>
+            <div className='flex justify-between mt-2 text-sm'>
+              <span className='font-medium'>Total Entered</span>
+              <span
+                className={
+                  "text-green-600 font-semibold flex items-center gap-1"
+                }
+              >
                 {formatCurrency(paymentsTotal)} / {formatCurrency(finalTotal)}
                 {paymentsTotal > finalTotal && (
-                  <span className="text-yellow-700 font-semibold">
-                    <Coins className="inline w-4 h-4 ml-1 text-yellow-500" />
-                    <span className="text-yellow-500 font-bold ml-1">{formatCurrency(paymentsTotal - finalTotal)}</span>
+                  <span className='text-yellow-700 font-semibold'>
+                    <Coins className='inline w-4 h-4 ml-1 text-yellow-500' />
+                    <span className='text-yellow-500 font-bold ml-1'>
+                      {formatCurrency(paymentsTotal - finalTotal)}
+                    </span>
                   </span>
                 )}
               </span>
@@ -216,40 +304,55 @@ const PaymentDialog: React.FC<PaymentDialogProps> = ({
         </div>
 
         {/* Right Column - Order Summary and Pay Button */}
-        <div className="md:w-1/2 p-6 overflow-y-auto">
-          {/* Error Message */}
+        <div className='md:w-1/2 p-6 overflow-y-auto'>
+          {/* Enhanced Error Message Display */}
           {error && (
-            <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg">
-              <p className="text-red-700 text-sm">{error}</p>
+            <div className='mb-6 p-4 bg-red-50 border-l-4 border-red-400 rounded-r-lg'>
+              <div className='flex items-start'>
+                <div className='flex-shrink-0'>
+                  <X className='w-5 h-5 text-red-400' />
+                </div>
+                <div className='ml-3'>
+                  <h3 className='text-sm font-medium text-red-800'>
+                    Payment Error
+                  </h3>
+                  <div className='mt-2 text-sm text-red-700'>
+                    <p className='whitespace-pre-line'>{error}</p>
+                  </div>
+                </div>
+              </div>
             </div>
           )}
 
           {/* Order Summary */}
-          <div className="space-y-3 mb-6">
-            <h3 className="text-lg font-semibold">Order Summary</h3>
-            <div className="space-y-2 text-sm">
+          <div className='space-y-3 mb-6'>
+            <h3 className='text-lg font-semibold'>Order Summary</h3>
+            <div className='space-y-2 text-sm'>
               {/* Subtotal (Grand Total) */}
-              <div className="flex justify-between">
-                <span className="text-gray-600">Subtotal</span>
+              <div className='flex justify-between'>
+                <span className='text-gray-600'>Subtotal</span>
                 <span>{formatCurrency(subtotal)}</span>
               </div>
               {/* Discount */}
               {appliedDiscount > 0 && (
-                <div className="flex justify-between text-green-600">
+                <div className='flex justify-between text-green-600'>
                   <span>Discount</span>
                   <span>-{formatCurrency(appliedDiscount)}</span>
                 </div>
               )}
               {/* Adjustment (if any) */}
               {showFinalAdjustment && (
-                <div className="flex justify-between text-blue-600">
+                <div className='flex justify-between text-blue-600'>
                   <span>Adjustment</span>
-                  <span>{roundedFinalAdjustment > 0 ? '+' : ''}{formatCurrency(roundedFinalAdjustment)}</span>
+                  <span>
+                    {roundedFinalAdjustment > 0 ? "+" : ""}
+                    {formatCurrency(roundedFinalAdjustment)}
+                  </span>
                 </div>
               )}
               {/* Final Total (Rounded) */}
-              <div className="border-t pt-2">
-                <div className="flex justify-between font-semibold text-lg">
+              <div className='border-t pt-2'>
+                <div className='flex justify-between font-semibold text-lg'>
                   <span>Total</span>
                   <span>{formatCurrency(finalTotal)}</span>
                 </div>
@@ -261,10 +364,16 @@ const PaymentDialog: React.FC<PaymentDialogProps> = ({
           <Button
             onClick={handlePayment}
             disabled={isProcessing || payments.length === 0}
-            variant={isProcessing || payments.length === 0 ? "secondary" : "default"}
-            className="w-full"
+            variant={
+              isProcessing || payments.length === 0 ? "secondary" : "default"
+            }
+            className='w-full'
           >
-            {isProcessing ? 'Processing...' : `Pay ${formatCurrency(paymentsTotal>0?paymentsTotal:finalTotal)}`}
+            {isProcessing
+              ? "Processing..."
+              : `Pay ${formatCurrency(
+                  paymentsTotal > 0 ? paymentsTotal : finalTotal
+                )}`}
           </Button>
         </div>
       </DialogContent>
@@ -272,4 +381,4 @@ const PaymentDialog: React.FC<PaymentDialogProps> = ({
   );
 };
 
-export default PaymentDialog; 
+export default PaymentDialog;

--- a/pos/src/components/ui/toast.tsx
+++ b/pos/src/components/ui/toast.tsx
@@ -29,7 +29,7 @@ export const showToast = {
   error: (message: string) => {
     toast.error(message, {
       position: 'top-right',
-      autoClose: 2000,
+      autoClose: 10000,
       hideProgressBar: false,
       closeOnClick: true,
       pauseOnHover: true,
@@ -60,7 +60,7 @@ export const ToastProvider = () => {
   return (
     <ToastContainer
       position="top-right"
-      autoClose={2000}
+      autoClose={100000}
       hideProgressBar={false}
       newestOnTop
       closeOnClick

--- a/ury/ury/hooks/ury_pos_invoice.py
+++ b/ury/ury/hooks/ury_pos_invoice.py
@@ -68,7 +68,7 @@ class URYPOSInvoice(POSInvoice):
 					if not bom:
 						frappe.throw(
 							_("Row #{0}: No default BOM found for QSR Item {1}").format(
-								d.idx, frappe.bold(d.item_code)
+								d.idx, d.item_code
 							)
 						)
 
@@ -87,7 +87,9 @@ class URYPOSInvoice(POSInvoice):
 								{
 									"row": d.idx,
 									"qsr_item": d.item_code,
+									"qsr_item_name": d.item_name,
 									"raw_material": rm_code,
+									"raw_material_name": rm["item_name"],
 									"required": required_qty,
 									"available": available_qty,
 								}
@@ -100,36 +102,36 @@ class URYPOSInvoice(POSInvoice):
 				continue
 
 			available_stock, is_stock_item = get_stock_availability(d.item_code, d.warehouse)
-			item_code, warehouse = d.item_code, d.warehouse
+			item_code, warehouse, item_name = d.item_code, d.warehouse, d.item_name
 
 			if is_stock_item and flt(available_stock) <= 0:
 				frappe.throw(
-					_("Row #{}: Item Code {} is not available under warehouse {}.").format(
-						d.idx, item_code, warehouse
+					_("Row #{}: Item [{}] {} is not available under warehouse {}.").format(
+						d.idx, item_code, item_name, warehouse
 					),
 					title=_("Item Unavailable"),
 				)
 			elif is_stock_item and flt(available_stock) < flt(d.stock_qty):
 				frappe.throw(
-					_("Row #{}: Stock quantity not enough for Item Code {} under warehouse {}.").format(
-						d.idx, item_code, warehouse
+					_("Row #{}: Stock quantity not enough for Item {} - [{}] under warehouse {}.").format(
+						d.idx, item_name, item_code, warehouse
 					),
 					title=_("Item Unavailable"),
 				)
 
 		# After checking all items → show one combined error if any raw materials are missing
 		if missing_materials:
-			messages = []
+			messages = ["Insufficient Raw Materials for the following QSR items:"]
 			for m in missing_materials:
 				messages.append(
-					_("Row #{0} | QSR Item: <b>{1}</b> → Raw Material: <b>{2}</b> "
+					_("-> Row #{0} | QSR Item: {1} Raw Material: {2} "
 					"(Required: {3}, Available: {4})").format(
-						m["row"], m["qsr_item"], m["raw_material"],
+						m["row"], m["qsr_item_name"], m["raw_material_name"],
 						m["required"], m["available"]
 					)
 				)
 			frappe.throw(
-				"<br>".join(messages),
+				"	".join(messages),
 				title=_("Insufficient Raw Materials")
 			)
 		else:

--- a/ury/ury/hooks/ury_pos_invoice.py
+++ b/ury/ury/hooks/ury_pos_invoice.py
@@ -100,7 +100,7 @@ class URYPOSInvoice(POSInvoice):
 				continue
 
 			available_stock, is_stock_item = get_stock_availability(d.item_code, d.warehouse)
-			item_code, warehouse = frappe.bold(d.item_code), frappe.bold(d.warehouse)
+			item_code, warehouse = d.item_code, d.warehouse
 
 			if is_stock_item and flt(available_stock) <= 0:
 				frappe.throw(

--- a/ury/ury/hooks/ury_pos_invoice.py
+++ b/ury/ury/hooks/ury_pos_invoice.py
@@ -4,7 +4,10 @@ import frappe
 from frappe import _
 from frappe.utils import flt, now
 
-from erpnext.accounts.doctype.pos_invoice.pos_invoice import POSInvoice, get_stock_availability
+from erpnext.accounts.doctype.pos_invoice.pos_invoice import (
+	POSInvoice,
+	get_stock_availability,
+)
 
 
 class URYPOSInvoice(POSInvoice):
@@ -13,7 +16,6 @@ class URYPOSInvoice(POSInvoice):
 		self.pos_invoice_naming()
 		self.order_type_update()
 		self.restrict_existing_order()
-
 
 	def validate(self):
 		super().validate()
@@ -26,12 +28,10 @@ class URYPOSInvoice(POSInvoice):
 
 		self.calculate_taxes_and_totals()
 
-
 	def before_submit(self):
 		self.calculate_and_set_times()
 		self.validate_invoice_print()
 		self.ro_reload_submit()
-
 
 	def on_trash(self):
 		self.table_status_delete()
@@ -64,7 +64,9 @@ class URYPOSInvoice(POSInvoice):
 			if item_group in qsr_item_groups:
 				# Find default BOM for the item
 				if self.docstatus.is_draft() and not self.skip_raw_material_validation:
-					bom = frappe.db.get_value("BOM", {"item": d.item_code, "is_default": 1}, "name")
+					bom = frappe.db.get_value(
+						"BOM", {"item": d.item_code, "is_default": 1}, "name"
+					)
 					if not bom:
 						frappe.throw(
 							_("Row #{0}: No default BOM found for QSR Item {1}").format(
@@ -74,7 +76,9 @@ class URYPOSInvoice(POSInvoice):
 
 					# Get raw materials from BOM
 					bom_items = get_bom_items_as_dict(bom, company=self.company)
-					source_warehouse = frappe.db.get_value("POS Profile", self.pos_profile, "warehouse")
+					source_warehouse = frappe.db.get_value(
+						"POS Profile", self.pos_profile, "warehouse"
+					)
 
 					for rm_code, rm in bom_items.items():
 						required_qty = flt(rm["qty"]) * flt(d.stock_qty)
@@ -101,92 +105,100 @@ class URYPOSInvoice(POSInvoice):
 			if is_negative_stock_allowed(item_code=d.item_code):
 				continue
 
-			available_stock, is_stock_item = get_stock_availability(d.item_code, d.warehouse)
+			available_stock, is_stock_item = get_stock_availability(
+				d.item_code, d.warehouse
+			)
 			item_code, warehouse, item_name = d.item_code, d.warehouse, d.item_name
 
 			if is_stock_item and flt(available_stock) <= 0:
 				frappe.throw(
-					_("Row #{}: Item [{}] {} is not available under warehouse {}.").format(
-						d.idx, item_code, item_name, warehouse
+					_("Row #{}: Item '{}' is out of stock in warehouse '{}'.").format(
+						d.idx, item_name, warehouse
 					),
 					title=_("Item Unavailable"),
 				)
 			elif is_stock_item and flt(available_stock) < flt(d.stock_qty):
 				frappe.throw(
-					_("Row #{}: Stock quantity not enough for Item {} - [{}] under warehouse {}.").format(
-						d.idx, item_name, item_code, warehouse
-					),
-					title=_("Item Unavailable"),
+					_(
+						"Row #{}: Insufficient stock for '{}'. Required: {}, Available: {} in warehouse '{}'."
+					).format(d.idx, item_name, d.stock_qty, available_stock, warehouse),
+					title=_("Insufficient Stock"),
 				)
 
 		# After checking all items → show one combined error if any raw materials are missing
 		if missing_materials:
-			messages = ["Insufficient Raw Materials for the following QSR items:"]
+			messages = ["Cannot process order - insufficient raw materials:"]
 			for m in missing_materials:
 				messages.append(
-					_("-> Row #{0} | QSR Item: {1} Raw Material: {2} "
-					"(Required: {3}, Available: {4})").format(
-						m["row"], m["qsr_item_name"], m["raw_material_name"],
-						m["required"], m["available"]
+					_("• {} requires {} {} (only {} available)").format(
+						m["qsr_item_name"],
+						m["required"],
+						m["raw_material_name"],
+						m["available"],
 					)
 				)
-			frappe.throw(
-				"	".join(messages),
-				title=_("Insufficient Raw Materials")
-			)
+			frappe.throw("\n".join(messages), title=_("Insufficient Raw Materials"))
 		else:
-			if self.docstatus.is_draft() and qsr_item_groups and not self.skip_raw_material_validation:
+			if (
+				self.docstatus.is_draft()
+				and qsr_item_groups
+				and not self.skip_raw_material_validation
+			):
 				self.skip_raw_material_validation = 1
-
 
 	def validate_invoice(self):
 		if self.waiter == None or self.waiter == "":
 			self.waiter = self.modified_by
-		remove_items = frappe.db.get_value("POS Profile", self.pos_profile, "remove_items")
-		
+		remove_items = frappe.db.get_value(
+			"POS Profile", self.pos_profile, "remove_items"
+		)
+
 		if self.invoice_printed == 1 and remove_items == 0:
 			# Get the original items from db
 			original_doc = frappe.get_doc("POS Invoice", self.name)
-			
+
 			# Create dictionaries to store both quantities and names
 			original_items = {
-				item.item_code: {"qty": item.qty, "name": item.item_name} 
+				item.item_code: {"qty": item.qty, "name": item.item_name}
 				for item in original_doc.items
 			}
 			current_items = {
-				item.item_code: {"qty": item.qty, "name": item.item_name} 
+				item.item_code: {"qty": item.qty, "name": item.item_name}
 				for item in self.items
 			}
-			
+
 			# Check for removed items
 			removed_items = set(original_items.keys()) - set(current_items.keys())
-			
+
 			# Check for quantity reductions
 			reduced_qty_items = []
 			for item_code, item_data in original_items.items():
-				if (item_code in current_items and 
-					current_items[item_code]["qty"] < item_data["qty"]):
+				if (
+					item_code in current_items
+					and current_items[item_code]["qty"] < item_data["qty"]
+				):
 					reduced_qty_items.append(
 						f"{item_data['name']} (qty reduced from {item_data['qty']} "
 						f"to {current_items[item_code]['qty']})"
 					)
-			
+
 			if removed_items or reduced_qty_items:
 				error_msg = []
 				if removed_items:
 					removed_item_names = [
-						original_items[item_code]["name"] 
-						for item_code in removed_items
+						original_items[item_code]["name"] for item_code in removed_items
 					]
 					error_msg.append(f"Removed items: {', '.join(removed_item_names)}")
 				if reduced_qty_items:
-					error_msg.append(f"Modified quantities: {', '.join(reduced_qty_items)}")
-					
-				frappe.throw(
-					("Cannot modify items after invoice is printed.\n{0}")
-					.format("\n".join(error_msg))
-				)
+					error_msg.append(
+						f"Modified quantities: {', '.join(reduced_qty_items)}"
+					)
 
+				frappe.throw(
+					("Cannot modify items after invoice is printed.\n{0}").format(
+						"\n".join(error_msg)
+					)
+				)
 
 	def validate_customer(self):
 		if self.customer_name == None or self.customer_name == "":
@@ -196,15 +208,14 @@ class URYPOSInvoice(POSInvoice):
 				)
 			)
 
-
 	def calculate_and_set_times(self):
 		self.arrived_time = self.creation
 
 		current_time_str = now()
 		creation_time = None
-		
+
 		current_time = datetime.strptime(current_time_str, "%Y-%m-%d %H:%M:%S.%f")
-		
+
 		if isinstance(self.creation, str):
 			creation_time = datetime.strptime(self.creation, "%Y-%m-%d %H:%M:%S.%f")
 		else:
@@ -215,21 +226,21 @@ class URYPOSInvoice(POSInvoice):
 		total_seconds = int(time_difference.total_seconds())
 		hours, remainder = divmod(total_seconds, 3600)
 		minutes, seconds = divmod(remainder, 60)
-		
+
 		formatted_spend_time = f"{hours:02d}:{minutes:02d}:{seconds:02d}"
 		self.total_spend_time = formatted_spend_time
 
-
 	def validate_invoice_print(self):
 		# Check if the invoice has been printed
-		invoice_printed = frappe.db.get_value("POS Invoice", self.name, "invoice_printed")
+		invoice_printed = frappe.db.get_value(
+			"POS Invoice", self.name, "invoice_printed"
+		)
 
 		# If the invoice is associated with a restaurant table and hasn't been printed
 		if self.restaurant_table and invoice_printed == 0:
 			frappe.throw(
 				"Printing the invoice is mandatory before submitting. Please print the invoice."
 			)
-
 
 	def table_status_delete(self):
 		if self.restaurant_table:
@@ -239,7 +250,6 @@ class URYPOSInvoice(POSInvoice):
 				{"occupied": 0, "latest_invoice_time": None},
 			)
 
-
 	def pos_invoice_naming(self):
 		pos_profile = frappe.get_doc("POS Profile", self.pos_profile)
 		restaurant = pos_profile.restaurant
@@ -248,13 +258,11 @@ class URYPOSInvoice(POSInvoice):
 			self.naming_series = frappe.db.get_value(
 				"URY Restaurant", restaurant, "invoice_series_prefix"
 			)
-			
+
 			if self.order_type == "Aggregators":
 				self.naming_series = frappe.db.get_value(
 					"URY Restaurant", restaurant, "aggregator_series_prefix"
 				)
-	
-
 
 	def order_type_update(self):
 		if self.restaurant_table:
@@ -266,52 +274,63 @@ class URYPOSInvoice(POSInvoice):
 					self.order_type = "Take Away"
 				else:
 					self.order_type = "Dine In"
-	
-
 
 	# reload restaurant order page if submitted invoice is open there
 	def ro_reload_submit(self):
 		frappe.publish_realtime("reload_ro", {"name": self.name})
 
-
 	def validate_price_list(self):
-			
+
 		if self.restaurant:
-			
+
 			if self.restaurant_table:
-				room = frappe.db.get_value("URY Table", self.restaurant_table, "restaurant_room")
+				room = frappe.db.get_value(
+					"URY Table", self.restaurant_table, "restaurant_room"
+				)
 				menu_name = (
-					frappe.db.get_value("URY Restaurant", self.restaurant, "active_menu")
+					frappe.db.get_value(
+						"URY Restaurant", self.restaurant, "active_menu"
+					)
 					if not frappe.db.get_value(
 						"URY Restaurant", self.restaurant, "room_wise_menu"
 					)
 					else frappe.db.get_value(
-						"Menu for Room", {"parent": self.restaurant, "room": room}, "menu"
+						"Menu for Room",
+						{"parent": self.restaurant, "room": room},
+						"menu",
 					)
 				)
 
 				self.selling_price_list = frappe.db.get_value(
 					"Price List", dict(restaurant_menu=menu_name, enabled=1)
 				)
-			
+
 			if self.order_type == "Aggregators":
-				price_list = frappe.db.get_value("Aggregator Settings",
-					{"customer": self.customer, "parent": self.branch, "parenttype": "Branch"},
+				price_list = frappe.db.get_value(
+					"Aggregator Settings",
+					{
+						"customer": self.customer,
+						"parent": self.branch,
+						"parenttype": "Branch",
+					},
 					"price_list",
-					)
-				
+				)
+
 				if not price_list:
-					frappe.throw(f"Price list for customer {self.customer} in branch {self.branch} not found in Aggregator Settings.")
-					
+					frappe.throw(
+						f"Price list for customer {self.customer} in branch {self.branch} not found in Aggregator Settings."
+					)
+
 				self.selling_price_list = price_list
-				
+
 			else:
-				menu_name = frappe.db.get_value("URY Restaurant", self.restaurant, "active_menu") 
+				menu_name = frappe.db.get_value(
+					"URY Restaurant", self.restaurant, "active_menu"
+				)
 
 				self.selling_price_list = frappe.db.get_value(
 					"Price List", dict(restaurant_menu=menu_name, enabled=1)
 				)
-			
 
 	def restrict_existing_order(self):
 		if self.restaurant_table:
@@ -339,9 +358,9 @@ class URYPOSInvoice(POSInvoice):
 
 		if not production_unit:
 			return []
-		
+
 		return frappe.get_all(
 			"URY Production Item Groups",
 			filters={"parent": production_unit},
-			pluck="item_group"
+			pluck="item_group",
 		)


### PR DESCRIPTION
This pull request enhances the stock availability validation logic in `ury_pos_invoice.py` to provide clearer and more informative error messages when items or raw materials are unavailable or insufficient. The changes improve user feedback by including item names alongside item codes and refining the error message formatting.

**Improvements to error messaging and data reporting:**

* Error messages now include both item codes and item names for better clarity when stock is unavailable or insufficient.
* When reporting missing raw materials, the messages now include both the QSR item name and the raw material name, making it easier to identify issues.
* The error message for missing BOMs no longer uses bold formatting for item codes, simplifying the output.
* The combined error message for insufficient raw materials now starts with a clear header and uses improved formatting for readability.
* The error toast now closes after 10 seconds instead of 2 seconds.

### Before

<table>
  <tr>
    <td><img width="400" alt="Before 1" src="https://github.com/user-attachments/assets/0f551ca6-254b-418b-b3d0-52bb1203b56d" /></td>
    <td><img width="400" alt="Before 2" src="https://github.com/user-attachments/assets/9fe326d3-2733-4ce4-ada9-2ad57d142cdb" /></td>
    <td><img width="400" alt="Before 2" src="https://github.com/user-attachments/assets/a79aa4f4-c3cf-4284-9cfc-dff507f8ea31" /></td>
  </tr>
</table>


### After

<table>
  <tr>
    <td><img width="400" alt="After 1" src="https://github.com/user-attachments/assets/0dfe29da-3022-48fc-91d2-8637627bc8b4" /></td>
    <td><img width="400" alt="After 2" src="https://github.com/user-attachments/assets/ccf31f16-5044-4874-ad8b-26444e1b08e6" /></td>
    <td><img width="400" alt="Before 2" src="https://github.com/user-attachments/assets/ddce28cf-fe73-4e72-a593-f2038b61e1bf" /></td>
  </tr>
</table>
