### PR TITLE
fix(stock_entry): align posting before POS Invoice by 1s

### DIFF
--- a/ury/ury/hooks/ury_pos_invoice.py
+++ b/ury/ury/hooks/ury_pos_invoice.py
@@ -396,7 +396,7 @@ class URYPOSInvoice(POSInvoice):
 				stock_entry_doc.submit()
 
 				# Align stock entry posting date/time with invoice
-				invoice_dt = datetime.combine(self.posting_date, datetime.strptime(self.posting_time, "%H:%M:%S").time())
+				invoice_dt = get_datetime(f"{self.posting_date} {self.posting_time}")
 
 				if invoice_dt.time().strftime("%H:%M:%S") == "00:00:00":
 					adjusted_dt = invoice_dt

--- a/ury/ury/hooks/ury_pos_invoice.py
+++ b/ury/ury/hooks/ury_pos_invoice.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import frappe
 from frappe import _
@@ -394,6 +394,23 @@ class URYPOSInvoice(POSInvoice):
 				stock_entry_doc = frappe.get_doc(stock_entry_data)  # Convert dict to Doc
 				stock_entry_doc.insert()
 				stock_entry_doc.submit()
+
+				# Align stock entry posting date/time with invoice
+				invoice_dt = datetime.combine(self.posting_date, datetime.strptime(self.posting_time, "%H:%M:%S").time())
+
+				if invoice_dt.time().strftime("%H:%M:%S") == "00:00:00":
+					adjusted_dt = invoice_dt
+				else:
+					adjusted_dt = invoice_dt - timedelta(seconds=1)
+
+				frappe.db.set_value(
+					"Stock Entry",
+					stock_entry_doc.name,
+					{
+						"posting_date": adjusted_dt.date(),
+						"posting_time": adjusted_dt.strftime("%H:%M:%S")
+					}
+				)
 			except NegativeStockError as e:
 				frappe.throw(
 					f"Cannot auto-complete Work Order {work_order.name}: insufficient stock.\n{e}"


### PR DESCRIPTION
Ensure Stock Entries created during auto-complete of Work Orders are always posted slightly before the linked POS Invoice. This prevents timing conflicts when closing POS, where the Stock Entry could otherwise appear a second later than the invoice. Posting time is adjusted by subtracting one second from the invoice’s posting timestamp, with safeguards for midnight edge cases.