### PR TITLE
Add in-app POS Opening/Closing dialogs to URY POS to remove reliance on Desk

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,5 +12,8 @@
   },
   "devDependencies": {
     "@types/qz-tray": "^2.2.2"
+  },
+  "dependencies": {
+    "react-currency-input-field": "^4.0.2"
   }
 }

--- a/pos/src/components/Header.tsx
+++ b/pos/src/components/Header.tsx
@@ -5,6 +5,7 @@ import {
   User,
   ChevronDown,
   Monitor,
+  MonitorX,
   LogOut,
   RefreshCw,
 } from 'lucide-react';
@@ -14,6 +15,7 @@ import { usePOSStore } from '../store/pos-store';
 import type { RootState } from '../store/root-store';
 import { logout } from '../lib/auth-api';
 import { showToast } from './ui/toast';
+import POSClosingDialog from './POSClosingDialog';
 
 const Header = () => {
   const [showUserMenu, setShowUserMenu] = useState(false);
@@ -24,6 +26,7 @@ const Header = () => {
   const { searchQuery, setSearchQuery } = usePOSStore();
   const { orderSearchQuery, setOrderSearchQuery } = useRootStore();
   const [orderSearchInput, setOrderSearchInput] = useState(orderSearchQuery);
+  const [showClosingModal, setShowClosingModal] = useState(false);
 
   // Determine placeholder and handlers based on route
   let searchPlaceholder = 'Search orders, menu items, or customers...';
@@ -173,6 +176,13 @@ const Header = () => {
                   </Button>
                   <Button
                     variant="ghost"
+                    className="flex justify-start items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 transition-colors"
+                    onClick={() => setShowClosingModal(true)}>
+                      <MonitorX className='w-4 h-4 mr-3' />
+                      Close POS
+                  </Button>
+                  <Button
+                    variant="ghost"
                     className="flex justify-start items-center w-full px-4 py-2 text-sm text-red-600 hover:bg-red-50 hover:text-red-700 transition-colors"
                     onClick={handleLogout}
                   >
@@ -185,6 +195,13 @@ const Header = () => {
           </div>
         </div>
       </div>
+      
+      {showClosingModal && (
+        <POSClosingDialog
+        onClose={() => setShowClosingModal(false)}
+        user={user}
+        />
+      )}
     </header>
   );
 };

--- a/pos/src/components/POSClosingDialog.tsx
+++ b/pos/src/components/POSClosingDialog.tsx
@@ -1,0 +1,209 @@
+import React, { useEffect, useState } from "react";
+import CurrencyInput from "react-currency-input-field";
+import { X, FileText, Loader2, Users } from "lucide-react";
+import { Dialog, DialogContent, Button } from "./ui";
+import { call } from "../lib/frappe-sdk";
+import { checkPOSOpening } from "../lib/pos-opening-api";
+import { formatCurrency, getCurrencySymbol } from "../lib/utils";
+
+interface POSClosingDialogProps {
+  onClose: () => void;
+  user: any;
+}
+
+const POSClosingDialog: React.FC<POSClosingDialogProps> = ({ onClose, user }) => {
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [openingEntry, setOpeningEntry] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [summary, setSummary] = useState<any | null>(null);
+  const currencySymbol = getCurrencySymbol();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        // find open POS Opening Entry
+        const opening = await checkPOSOpening();
+        if (!opening?.message) {
+          setError("No active POS opening entry found.");
+          return;
+        }
+        setOpeningEntry(opening.message.opening_entry);
+
+        // Preview the summary
+        const res = await call.get("ury.ury_pos.api.get_closing_preview", {
+          pos_opening_entry: opening.message.opening_entry,
+        });
+
+        if (res.message) {
+          setSummary(res.message);
+        }
+      } catch (err) {
+        console.error("Error loading POS data", err);
+        setError("Failed to fetch POS closing data.");
+      }
+    };
+
+    fetchData();
+  }, [user]);
+
+  const handleClosePOS = async () => {
+    setIsProcessing(true);
+    setError(null);
+    try {
+      const res = await call.post("ury.ury_pos.api.submit_pos_closing", {
+        pos_opening_entry: openingEntry,
+        closing_amounts: summary.payments.map((p: any) => ({
+          mode_of_payment: p.mode_of_payment,
+          closing_amount: p.closing_amount || 0,
+        }))
+      });
+
+      if (res.message?.status === "success") {
+        if ((window as any).showToast) {
+          (window as any).showToast.success("POS closed successfully");
+        }
+        window.location.reload();
+        onClose();
+      } else {
+        setError(res.message?.message || "Failed to close POS.");
+      }
+    } catch (err: any) {
+      console.error("Error closing POS:", err);
+      setError("Failed to close POS.");
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  return (
+    <Dialog open={true} onOpenChange={() => {}} dismissible={false}>
+      <DialogContent
+        variant="xlarge"
+        className="bg-white w-full max-w-4xl max-h-[90vh] flex flex-col p-0"
+        showCloseButton={false}
+      >
+        <div className="flex justify-between items-center p-4 border-b border-gray-200">
+          <h2 className="text-2xl font-bold">Close POS</h2>
+          <Button onClick={onClose} variant="ghost" size="icon">
+            <X className="w-5 h-5" />
+          </Button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto p-6 space-y-6">
+          {error && (
+            <div className="mb-6 p-4 bg-red-50 border-l-4 border-red-400 rounded-r-lg text-sm text-red-700">
+              {error}
+            </div>
+          )}
+
+            {/* Invoices */}
+            {summary?.pos_transactions?.length > 0 && (
+              <div className="space-y-3">
+                <h3 className="text-lg font-semibold mb-3 flex items-center gap-2">
+                  <FileText className="w-5 h-5" /> Invoices
+                </h3>
+                <ul className="divide-y border rounded-md">
+                  {summary.pos_transactions.map((inv: any) => (
+                    <li key={inv.name} className="flex justify-between px-4 py-2 text-sm">
+                      <span className="w-32">{inv.pos_invoice}</span>
+                      <span className="w-28">{inv.posting_date}</span>
+                      <span className="w-36">{formatCurrency(inv.grand_total || 0)}</span>
+                    </li>
+                  ))}
+                </ul>
+                <div className="flex justify-between mt-4 font-semibold">
+                  <span>Total</span>
+                  <span>{formatCurrency(summary.grand_total)}</span>
+                </div>
+              </div>
+            )}
+
+          {/* Summary by Waiter */}
+          {summary?.waiter_summary?.length > 0 && (
+            <div className="space-y-3">
+              <h3 className="text-lg font-semibold mb-3 flex items-center gap-2">
+                <Users className="w-5 h-5" /> Summary by Waiter
+              </h3>
+              <ul className="divide-y border rounded-md">
+                {summary.waiter_summary.map((row: any) => (
+                  <li key={row.waiter} className="flex justify-between px-4 py-2 text-sm">
+                    <span>
+                      {row.waiter} ({row.invoices} invoices)
+                    </span>
+                    <span>{formatCurrency(row.total)}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {/* Payments */}
+          {summary?.payments?.length > 0 && (
+            <div className="space-y-3">
+              <h3 className="text-lg font-semibold mb-3">Payments</h3>
+              <ul className="divide-y border rounded-md">
+                {summary.payments.map((row: any, idx: number) => (
+                  <li key={idx} className="flex items-center justify-between px-4 py-2 text-sm gap-2">
+                    <span className="w-48 truncate">{row.mode_of_payment}</span>
+                    <CurrencyInput
+                      className="w-36 border rounded px-2 py-1 text-right"
+                      placeholder="Enter actual"
+                      decimalsLimit={2}
+                      prefix={currencySymbol + " "}
+                      defaultValue={row.expected_amount}
+                      onValueChange={(value) => {
+                        const numeric = value ? parseFloat(value) : 0;
+                        setSummary((prev: any) => {
+                          const updated = { ...prev };
+                          updated.payments[idx].closing_amount = numeric;
+                          return updated;
+                        });
+                      }}
+                    />
+                    <span className="w-32 text-right">{formatCurrency(row.expected_amount)}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {/* Taxes */}
+          {summary?.taxes?.length > 0 && (
+            <div className="space-y-3">
+              <h3 className="text-lg font-semibold mb-3">Taxes</h3>
+              <ul className="divide-y border rounded-md">
+                {summary.taxes.map((row: any, idx: number) => (
+                  <li key={idx} className="flex justify-between px-4 py-2 text-sm">
+                    <span>
+                      {row.account_head} ({row.rate}%)
+                    </span>
+                    <span>{formatCurrency(row.amount)}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+
+        <div className="p-4 border-t border-gray-200">
+          <Button
+            onClick={handleClosePOS}
+            disabled={isProcessing || !openingEntry}
+            className="w-full"
+          >
+            {isProcessing ? (
+              <span className="flex items-center gap-2">
+                <Loader2 className="w-4 h-4 animate-spin" />
+                Closing...
+              </span>
+            ) : (
+              "Confirm Close"
+            )}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default POSClosingDialog;

--- a/pos/src/components/POSClosingDialog.tsx
+++ b/pos/src/components/POSClosingDialog.tsx
@@ -23,15 +23,15 @@ const POSClosingDialog: React.FC<POSClosingDialogProps> = ({ onClose, user }) =>
       try {
         // find open POS Opening Entry
         const opening = await checkPOSOpening();
-        if (!opening?.message) {
+        if (!opening?.opening_entry) {
           setError("No active POS opening entry found.");
           return;
         }
-        setOpeningEntry(opening.message.opening_entry);
+        setOpeningEntry(opening.opening_entry);
 
         // Preview the summary
         const res = await call.get("ury.ury_pos.api.get_closing_preview", {
-          pos_opening_entry: opening.message.opening_entry,
+          pos_opening_entry: opening.opening_entry,
         });
 
         if (res.message) {
@@ -119,7 +119,7 @@ const POSClosingDialog: React.FC<POSClosingDialogProps> = ({ onClose, user }) =>
             )}
 
           {/* Summary by Waiter */}
-          {summary?.waiter_summary?.length > 0 && (
+          {/* {summary?.waiter_summary?.length > 0 && (
             <div className="space-y-3">
               <h3 className="text-lg font-semibold mb-3 flex items-center gap-2">
                 <Users className="w-5 h-5" /> Summary by Waiter
@@ -135,7 +135,7 @@ const POSClosingDialog: React.FC<POSClosingDialogProps> = ({ onClose, user }) =>
                 ))}
               </ul>
             </div>
-          )}
+          )} */}
 
           {/* Payments */}
           {summary?.payments?.length > 0 && (

--- a/pos/src/components/POSOpeningDialog.tsx
+++ b/pos/src/components/POSOpeningDialog.tsx
@@ -1,5 +1,10 @@
-import { RefreshCw, AlertTriangle, Monitor } from 'lucide-react';
+import { RefreshCw, AlertTriangle } from 'lucide-react';
+import { useState, useEffect } from 'react';
 import { Button } from './ui';
+import { call } from '../lib/frappe-sdk';
+import { getCombinedPosProfile } from '../lib/pos-profile-api';
+import CurrencyInput from 'react-currency-input-field';
+import { getCurrencySymbol } from '../lib/utils';
 
 interface POSOpeningDialogProps {
   onReload: () => void;
@@ -8,61 +13,147 @@ interface POSOpeningDialogProps {
 
 const POSOpeningDialog = ({ onReload, type }: POSOpeningDialogProps) => {
   const isOpeningIssue = type === 'opening';
+  const [showForm, setShowForm] = useState(false);
+  const [profile, setProfile] = useState<any[]>([]);
+  const [balanceDetails, setBalanceDetails] = useState<any[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  // When form opens, fetch profile and payment methods
+  useEffect(() => {
+    if (!showForm) return;
+    (async () => {
+      const p = await getCombinedPosProfile();
+      setProfile(p);
+
+      const res = await call.get('frappe.client.get', {
+        doctype: 'POS Profile',
+        name: p.name,
+      });
+
+      setBalanceDetails(
+        (res.message?.payments || []).map((pay: any) => ({
+          mode_of_payment: pay.mode_of_payment,
+          opening_amount: 0,
+        }))
+      );
+    })();
+  }, [showForm]);
+
+  const handleSubmit = async () => {
+    if (!profile) return;
+    setLoading(true);
+
+    try {
+      const res = await call.post('ury.ury_pos.api.create_opening_voucher', {
+        pos_profile: profile.name,
+        company: profile.company,
+        branch: profile.branch,
+        warehouse: profile.warehouse,
+        balance_details: balanceDetails,
+      });
+
+      if (res.message?.status === 'success') {
+        onReload();
+      } else {
+        alert(res.message?.message || 'Failed to create POS Opening Entry');
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
   
   const handleSwitchToDesk = () => {
     // Get the current domain and open /app in a new tab
     const currentDomain = window.location.origin;
     window.open(`${currentDomain}/app`, '_blank');
   };
-  
-  return (
+
+return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-      <div className="bg-white rounded-lg p-8 max-w-md w-full mx-4 shadow-xl">
-        <div className="text-center">
-          {/* Icon */}
-          <div className={`mx-auto flex items-center justify-center h-16 w-16 rounded-full mb-6 ${
-            isOpeningIssue ? 'bg-red-100' : 'bg-orange-100'
-          }`}>
-            {isOpeningIssue ? (
-              <RefreshCw className="h-8 w-8 text-red-600" />
-            ) : (
-              <AlertTriangle className="h-8 w-8 text-orange-600" />
-            )}
-          </div>
-          
-          {/* Title */}
-          <h2 className="text-2xl font-bold text-gray-900 mb-4">
-            {isOpeningIssue ? 'POS Not Opened' : 'Previous POS Not Closed'}
-          </h2>
-          
-          {/* Message */}
-          <p className="text-gray-600 mb-8 text-lg">
-            {isOpeningIssue 
-              ? 'Please open POS Entry to continue using the system.'
-              : 'Please close the previous POS Entry to continue.'
-            }
-          </p>
-          
-          {/* Buttons */}
-          <div className="space-y-3">
-            <Button
-              onClick={onReload}
-              className="w-full bg-blue-600 hover:bg-blue-700 text-white font-medium py-3 px-6 rounded-lg transition-colors duration-200"
+      <div className="bg-white rounded-lg p-8 max-w-3xl w-full mx-4 shadow-xl">
+        {!showForm ? (
+          <div className="text-center">
+            {/* Icon */}
+            <div
+              className={`mx-auto flex items-center justify-center h-16 w-16 rounded-full mb-6 ${
+                isOpeningIssue ? 'bg-red-100' : 'bg-orange-100'
+              }`}
             >
-              <RefreshCw className="w-5 h-5 mr-2" />
-              Reload Page
-            </Button>
-            
-            <Button
-              onClick={handleSwitchToDesk}
-              variant="outline"
-              className="w-full border-gray-300 text-gray-700 hover:bg-gray-50 font-medium py-3 px-6 rounded-lg transition-colors duration-200"
-            >
-              <Monitor className="w-5 h-5 mr-2" />
-              Switch to Desk
-            </Button>
+              {isOpeningIssue ? (
+                <RefreshCw className="h-8 w-8 text-red-600" />
+              ) : (
+                <AlertTriangle className="h-8 w-8 text-orange-600" />
+              )}
+            </div>
+
+            {/* Title */}
+            <h2 className="text-2xl font-bold text-gray-900 mb-4">
+              {isOpeningIssue ? 'POS Not Opened' : 'Previous POS Not Closed'}
+            </h2>
+
+            <p className="text-gray-600 mb-8 text-lg">
+              {isOpeningIssue
+                ? 'Please open POS Entry to continue using the system.'
+                : 'Please close the previous POS Entry to continue.'}
+            </p>
+
+            {/* Buttons */}
+            <div className="space-y-3">
+              <Button onClick={onReload} className="w-full bg-blue-600 text-white">
+                <RefreshCw className="w-5 h-5 mr-2" />
+                Reload Page
+              </Button>
+
+              {isOpeningIssue && (
+                <Button
+                  onClick={() => setShowForm(true)}
+                  variant="outline"
+                  className="w-full border-gray-300 text-gray-700"
+                >
+                  Open POS Entry
+                </Button>
+              )}
+            </div>
           </div>
-        </div>
+        ) : (
+          <div>
+            <h2 className="text-xl font-bold mb-4">Create POS Opening Entry</h2>
+
+            {/* Profile details  */}
+            <div className="mb-6 space-y-2 text-sm text-gray-700 border rounded p-4 bg-gray-50">
+              <div><strong>Company:</strong> {profile.company}</div>
+              <div><strong>POS Profile:</strong> {profile.name}</div>
+            </div>
+
+            {/* Payment inputs  */}
+            {balanceDetails.map((row, idx) => (
+              <div key={idx} className="flex justify-between mb-2">
+                <span>{row.mode_of_payment}</span>
+                <CurrencyInput
+                  className="w-28 border rounded px-2 py-1 text-right"
+                  placeholder="Opening Amount"
+                  decimalsLimit={2}
+                  prefix={getCurrencySymbol() + " "}
+                  defaultValue={0}
+                  onValueChange={(e) => {
+                    const updated = [...balanceDetails];
+                    updated[idx].opening_amount = parseFloat(e.target.value) || 0;
+                    setBalanceDetails(updated);
+                  }}
+                />
+              </div>
+            ))}
+
+            <div className="flex justify-end gap-2 mt-6">
+              <Button onClick={() => setShowForm(false)} variant="outline">
+                Cancel
+              </Button>
+              <Button onClick={handleSubmit} disabled={loading}>
+                {loading ? 'Submitting...' : 'Submit'}
+              </Button>
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/pos/src/components/POSOpeningDialog.tsx
+++ b/pos/src/components/POSOpeningDialog.tsx
@@ -1,10 +1,11 @@
-import { RefreshCw, AlertTriangle } from 'lucide-react';
+import { RefreshCw, AlertTriangle, MonitorX } from 'lucide-react';
 import { useState, useEffect } from 'react';
 import { Button } from './ui';
 import { call } from '../lib/frappe-sdk';
 import { getCombinedPosProfile } from '../lib/pos-profile-api';
 import CurrencyInput from 'react-currency-input-field';
 import { getCurrencySymbol } from '../lib/utils';
+import POSClosingDialog from './POSClosingDialog';
 
 interface POSOpeningDialogProps {
   onReload: () => void;
@@ -14,9 +15,15 @@ interface POSOpeningDialogProps {
 const POSOpeningDialog = ({ onReload, type }: POSOpeningDialogProps) => {
   const isOpeningIssue = type === 'opening';
   const [showForm, setShowForm] = useState(false);
+  const [showClosingDialog, setShowClosingDialog] = useState(false);
   const [profile, setProfile] = useState<any[]>([]);
   const [balanceDetails, setBalanceDetails] = useState<any[]>([]);
   const [loading, setLoading] = useState(false);
+
+  const handleClosedPOS = () => {
+    setShowClosingDialog(false);
+    onReload();
+  }
 
   // When form opens, fetch profile and payment methods
   useEffect(() => {
@@ -71,7 +78,10 @@ const POSOpeningDialog = ({ onReload, type }: POSOpeningDialogProps) => {
 return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
       <div className="bg-white rounded-lg p-8 max-w-3xl w-full mx-4 shadow-xl">
-        {!showForm ? (
+        {/* If user needs to close yesterday's POS  */}
+        {type === "closing" && showClosingDialog ? (
+          <POSClosingDialog onClose={handleClosedPOS} user={null} />
+        ) : !showForm ? (
           <div className="text-center">
             {/* Icon */}
             <div
@@ -99,19 +109,40 @@ return (
 
             {/* Buttons */}
             <div className="space-y-3">
-              <Button onClick={onReload} className="w-full bg-blue-600 text-white">
-                <RefreshCw className="w-5 h-5 mr-2" />
-                Reload Page
-              </Button>
-
-              {isOpeningIssue && (
-                <Button
-                  onClick={() => setShowForm(true)}
-                  variant="outline"
-                  className="w-full border-gray-300 text-gray-700"
-                >
-                  Open POS Entry
-                </Button>
+              {isOpeningIssue ? (
+                <>
+                  <Button 
+                    onClick={onReload} 
+                    className="w-full bg-blue-600 text-white"
+                  >
+                    <RefreshCw className="w-5 h-5 mr-2" />
+                    Reload Page
+                  </Button>
+                  <Button
+                    onClick={() => setShowForm(true)}
+                    variant="outline"
+                    className="w-full border-gray-300 text-gray-700"
+                  >
+                    Open POS Entry
+                  </Button>
+                </>
+              ) : (
+                <>
+                  <Button 
+                      onClick={onReload} 
+                      className="w-full bg-blue-600 text-white"
+                    >
+                      <RefreshCw className="w-5 h-5 mr-2" />
+                      Reload Page
+                  </Button>
+                  <Button
+                    onClick={() => setShowClosingDialog(true)}
+                    className="w-full bg-orange-600 text-white"
+                  >
+                    <MonitorX className="w-5 h-5 mr-2" />
+                    Close Previous POS
+                  </Button>
+                </>
               )}
             </div>
           </div>
@@ -135,9 +166,9 @@ return (
                   decimalsLimit={2}
                   prefix={getCurrencySymbol() + " "}
                   defaultValue={0}
-                  onValueChange={(e) => {
+                  onValueChange={(value) => {
                     const updated = [...balanceDetails];
-                    updated[idx].opening_amount = parseFloat(e.target.value) || 0;
+                    updated[idx].opening_amount = parseFloat(value) || 0;
                     setBalanceDetails(updated);
                   }}
                 />

--- a/pos/src/components/POSOpeningProvider.tsx
+++ b/pos/src/components/POSOpeningProvider.tsx
@@ -20,7 +20,8 @@ const POSOpeningProvider = ({ children }: POSOpeningProviderProps) => {
       
       // First check if POS is opened
       const openingResponse = await checkPOSOpening();
-      if (openingResponse.message === 1) {
+      console.log(openingResponse);
+      if (openingResponse.status === "not_opened") {
         // POS is not opened
         setValidationType('opening');
         return;

--- a/pos/src/components/ui/dialog.tsx
+++ b/pos/src/components/ui/dialog.tsx
@@ -68,10 +68,24 @@ export interface DialogProps
     VariantProps<typeof dialogVariants> {
   open?: boolean
   onOpenChange?: (open: boolean) => void
+  dismissible?: boolean
 }
 
 const Dialog = React.forwardRef<HTMLDivElement, DialogProps>(
-  ({ className, variant, open, onOpenChange, children, ...props }, ref) => {
+  ({ className, variant, open, onOpenChange, dismissible = true, children, ...props }, ref) => {
+    // Escape Key handling
+    React.useEffect(() => {
+      const handler = (e: KeyboardEvent) => {
+        if (e.key === "Escape") {
+          e.preventDefault()
+          // only close if dismissible
+          if (dismissible) onOpenChange?.(false)
+        }
+      }
+      document.addEventListener("keydown", handler)
+      return () => document.removeEventListener("keydown", handler)
+    }, [dismissible, onOpenChange])
+
     if (!open) return null
 
     return (
@@ -82,7 +96,9 @@ const Dialog = React.forwardRef<HTMLDivElement, DialogProps>(
       >
         <div
           className={cn(overlayVariants({ variant }))}
-          onClick={() => onOpenChange?.(false)}
+          onClick={() => {
+            if (dismissible) onOpenChange?.(false)
+          }}
         />
         {children}
       </div>

--- a/pos/src/lib/pos-opening-api.ts
+++ b/pos/src/lib/pos-opening-api.ts
@@ -1,7 +1,7 @@
 import { call } from './frappe-sdk';
 
 export interface POSOpeningResponse {
-  message: number;
+  opening_entry: string | null;
 }
 
 export interface POSCloseValidationResponse {

--- a/pos/src/lib/pos-opening-api.ts
+++ b/pos/src/lib/pos-opening-api.ts
@@ -1,7 +1,12 @@
 import { call } from './frappe-sdk';
 
-export interface POSOpeningResponse {
+export interface POSOpeningStatus {
+  status: 'not_opened' | 'open';
   opening_entry: string | null;
+}
+
+export interface POSOpeningResponse {
+  message: POSOpeningStatus;
 }
 
 export interface POSCloseValidationResponse {
@@ -14,7 +19,7 @@ export const checkPOSOpening = async (): Promise<POSOpeningResponse> => {
       'ury.ury_pos.api.posOpening'
     );
     
-    return response;
+    return response.message;
   } catch (error) {
     console.error('Error checking POS opening status:', error);
     throw error;

--- a/pos/src/lib/utils.ts
+++ b/pos/src/lib/utils.ts
@@ -6,7 +6,25 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-export function formatCurrency(amount: number): string {
-  const symbol = storage.getItem('currencySymbol');
-  return `${symbol} ${amount}`;
-} 
+export function getCurrencySymbol(): string {
+  return storage.getItem("currencySymbol") || "";
+}
+
+export function formatCurrency(amount: number, currencyCode?: string): string {
+  const symbol = getCurrencySymbol();
+  const code = currencyCode || storage.getItem("currencyCode") || "USD";
+
+  const formatter = new Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency: code,
+    currencyDisplay: "symbol",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2
+  })
+
+  let formatted = formatter.format(amount);
+  if (symbol) {
+    formatted = formatted.replace(/^[^\d]+/, symbol + " ")
+  }
+  return formatted;
+}

--- a/ury/ury_pos/api.py
+++ b/ury/ury_pos/api.py
@@ -641,10 +641,17 @@ def posOpening():
         fields=["name", "docstatus", "status", "posting_date"],
         filters={"branch": branchName, "status": "Open", "docstatus": 1, "user": frappe.session.user},
     )
+    print(pos_opening_list)
     if not pos_opening_list:
-        frappe.throw("No open POS Opening Entry found. Please open the POS before continuing.")
+        return {
+            "status": "not_opened",
+            "opening_entry": None
+        }
     
-    return {"opening_entry": pos_opening_list[0].name}
+    return {
+        "status": "open",
+        "opening_entry": pos_opening_list[0].name
+    }
 
 
 @frappe.whitelist()
@@ -727,6 +734,7 @@ def validate_pos_close(pos_profile):
                 "status": "Open",
                 "pos_profile": pos_profile,
                 "docstatus": 1,
+                "user": frappe.session.user,
             },
         )
 

--- a/ury/ury_pos/api.py
+++ b/ury/ury_pos/api.py
@@ -1,6 +1,15 @@
+import json
+from datetime import date, datetime, timedelta
+
+
 import frappe
 from frappe import _
-from datetime import date, datetime, timedelta
+from frappe.utils import flt, get_datetime
+
+from erpnext.accounts.doctype.pos_closing_entry.pos_closing_entry import (
+    make_closing_entry_from_opening,
+    get_pos_invoices
+)
 
 
 @frappe.whitelist()
@@ -630,15 +639,12 @@ def posOpening():
     pos_opening_list = frappe.get_all(
         "POS Opening Entry",
         fields=["name", "docstatus", "status", "posting_date"],
-        filters={"branch": branchName},
+        filters={"branch": branchName, "status": "Open", "docstatus": 1, "user": frappe.session.user},
     )
-    flag = 1
-    for pos_opening in pos_opening_list:
-        if pos_opening.status == "Open" and pos_opening.docstatus == 1:
-            flag = 0
-    if flag == 1:
-        frappe.msgprint(title="Message", indicator="red", msg=("Please Open POS Entry"))
-    return flag
+    if not pos_opening_list:
+        frappe.throw("No open POS Opening Entry found. Please open the POS before continuing.")
+    
+    return {"opening_entry": pos_opening_list[0].name}
 
 
 @frappe.whitelist()
@@ -770,3 +776,84 @@ def getAllOrders(limit, limit_start):
         next = False
 
     return {"data": updatedlist, "next": next}
+
+@frappe.whitelist()
+def create_opening_voucher(company: str, pos_profile: str, balance_details: list):
+    try:
+        
+        new_pos_opening = frappe.get_doc(
+            {
+                "doctype": "POS Opening Entry",
+                "period_start_date": frappe.utils.get_datetime(),
+                "posting_date": frappe.utils.getdate(),
+                "user": frappe.session.user,
+                "pos_profile": pos_profile,
+                "company": company,
+            }
+        )
+        new_pos_opening.set("balance_details", balance_details)
+        new_pos_opening.submit()
+
+        return {"status": "success", "opening_entry": new_pos_opening.name}
+    except Exception as e:
+        frappe.log_error(frappe.get_traceback(), "POS Opening Creation Failed")
+        return {"status": "error", "message": str(e)}
+
+@frappe.whitelist()
+def get_closing_preview(pos_opening_entry: str):
+    """Return a preview summary for the dialog (doesn't save anything)."""
+    opening_entry = frappe.get_doc("POS Opening Entry", pos_opening_entry)
+    closing_entry = make_closing_entry_from_opening(opening_entry)
+
+    # waiter summary
+    invoices = get_pos_invoices(
+        closing_entry.period_start_date,
+        closing_entry.period_end_date,
+        closing_entry.pos_profile,
+        closing_entry.user,
+    )
+    waiter_map = {}
+    for inv in invoices:
+        waiter = inv.get("owner") or "Unassigned"
+        if waiter not in waiter_map:
+            waiter_map[waiter] = {"waiter": waiter, "total": 0.0, "invoices": 0}
+        waiter_map[waiter]["invoices"] += 1
+        waiter_map[waiter]["total"] += flt(inv.get("grand_total") or 0.0)
+
+    waiter_summary = list(waiter_map.values())
+    # Convert child tables on the closing_entry into serializable dicts
+    payment_reconciliation = [p.as_dict() for p in closing_entry.payment_reconciliation]
+    taxes = [t.as_dict() for t in closing_entry.taxes]
+    pos_transactions = [p.as_dict() for p in closing_entry.pos_transactions]
+
+    return {
+        "grand_total": closing_entry.grand_total,
+        "net_total": closing_entry.net_total,
+        "total_quantity": closing_entry.total_quantity,
+        "taxes": taxes,
+        "payments": payment_reconciliation,
+        "pos_transactions": pos_transactions,
+        "waiter_summary": waiter_summary,
+    }
+
+
+@frappe.whitelist()
+def submit_pos_closing(pos_opening_entry: str, closing_amounts: list = None):
+    """Actually create & submit a POS Closing Entry."""
+    try:
+        opening_entry = frappe.get_doc("POS Opening Entry", pos_opening_entry)
+        closing_entry = make_closing_entry_from_opening(opening_entry)
+
+        # inject actual amounts
+        if closing_amounts:
+            closing_map = {p["mode_of_payment"]: p["closing_amount"] for p in closing_amounts}
+            for row in closing_entry.payment_reconciliation:
+                row.closing_amount = closing_map.get(row.mode_of_payment, 0)
+                row.difference = row.closing_amount - row.expected_amount
+        
+        closing_entry.insert(ignore_permissions=True)
+        closing_entry.submit()
+        return {"status": "success", "closing_entry": closing_entry.name}
+    except Exception as e:
+        frappe.log_error(frappe.get_traceback(), "POS Closing Failed")
+        return {"status": "error", "message": str(e)}


### PR DESCRIPTION
# ✨ Feature: Open/Close POS directly from URY POS  

This PR introduces the ability for cashiers to **open and close POS sessions without leaving the URY POS page**, eliminating the need to switch back to Desk.  

## 🔑 Key Features  
- **POS Opening Flow**
  - Blocking dialog if no active POS Opening Entry exists.  
  - Inline form to create a new POS Opening Entry, including opening balance details for all payment modes.  
  - Displays context (Company, POS Profile) for clarity.  
  - Enlarged modal for better visibility and input experience.  

- **POS Closing Flow**
  - Blocking dialog when an open POS needs closing before continuing.  
  - Shows closing preview with:
    - Invoices list  
    - Payments summary (with editable closing amounts)  
    - Taxes  
  - Prevents dismissing/closing the dialog while processing.  
  - Reloads page after successful closing to re-check POS Opening status.  

## 🛠️ Supporting Enhancements  
- **API Updates**
  - Added `create_opening_voucher` to facilitate opening of opening vouchers.  
  - Added endpoints for closing preview and submission.  

- **Dialog Component**
  - Introduced variants for larger/fullscreen layouts.  
  - Added non-dismissible mode (overlay click / escape key disabled) for critical flows.  

- **UI/UX Improvements**
  - Consistent use of `formatCurrency` and `getCurrencySymbol`.  
  - Inline error handling with both toast + inline error messages.  
  - Cleaner, consistent buttons and action layouts.  

## 🎯 Outcome  
Cashiers can now **manage POS Opening and Closing entirely within URY POS**, reducing errors, saving time, and improving the cashier workflow.  
