### PR TITLE
fix: POS closing issue

### DIFF
--- a/ury/ury_pos/api.py
+++ b/ury/ury_pos/api.py
@@ -1,5 +1,9 @@
 import json
 from datetime import date, datetime, timedelta
+from erpnext.accounts.doctype.pos_closing_entry.pos_closing_entry import (
+    make_closing_entry_from_opening,
+    get_pos_invoices,
+)
 
 
 import frappe


### PR DESCRIPTION
This pull request adds new import statements to the `ury/ury_pos/api.py` file, bringing in functions related to POS closing entries from `erpnext`. These imports will enable the use of closing entry creation and POS invoice retrieval functionality in this module.

* Added imports for `make_closing_entry_from_opening` and `get_pos_invoices` from `erpnext.accounts.doctype.pos_closing_entry.pos_closing_entry` to support POS closing operations.