### PR TITLE
Enhance POS printing flow — use in-page print dialog instead of new tab

### DIFF
--- a/pos/src/components/ui/toast.tsx
+++ b/pos/src/components/ui/toast.tsx
@@ -29,7 +29,7 @@ export const showToast = {
   error: (message: string) => {
     toast.error(message, {
       position: 'top-right',
-      autoClose: 10000,
+      autoClose: 5000,
       hideProgressBar: false,
       closeOnClick: true,
       pauseOnHover: true,
@@ -60,7 +60,7 @@ export const ToastProvider = () => {
   return (
     <ToastContainer
       position="top-right"
-      autoClose={100000}
+      autoClose={50000}
       hideProgressBar={false}
       newestOnTop
       closeOnClick

--- a/pos/src/pages/Orders.tsx
+++ b/pos/src/pages/Orders.tsx
@@ -200,11 +200,45 @@ export default function Orders() {
         selectedOrder.name
       )}&format=${encodeURIComponent(printFormat)}&no_letterhead=0&_lang=en`;
 
+      // Fetch printable HTML
+      const response = await fetch(printUrl, {
+        credentials: "include",
+      })
+
+      if (!response.ok) {
+        throw new Error("Failed to fetch print content");
+      }
+
+      const html = await response.text();
+
+      // Create a hidden iframe for printing
+      const printFrame = document.createElement("iframe");
+      printFrame.style.position = "fixed";
+      printFrame.style.right = "0";
+      printFrame.style.bottom = "0";
+      printFrame.style.width = "0";
+      printFrame.style.height = "0";
+      printFrame.style.border = "0";
+      document.body.appendChild(printFrame);
+
+      const frameDoc = printFrame.contentWindow?.document;
+      frameDoc?.open();
+      frameDoc?.write(html);
+      frameDoc?.close();
+
+      // Wait for iframe content to fully load before printing
+      printFrame.onload = () => {
+        printFrame.contentWindow?.focus();
+        printFrame.contentWindow?.print();
+
+        setTimeout(() => document.body.removeChild(printFrame), 2000);
+      }
+
       // const printUrl = `/app/print/${encodeURIComponent("POS Invoice")}/${encodeURIComponent(
       //     selectedOrder.name
       //   )}?format=${encodeURIComponent(printFormat)}&no_letterhead=0`;
 
-      window.open(printUrl, "_blank");
+      // window.open(printUrl, "_blank");
 
       // Update backend to mark invoice as printed
       await call.post("frappe.client.set_value", {


### PR DESCRIPTION
## Summary
This update improves the POS printing experience by prompting the user to print directly within the current page instead of opening a new browser tab or window.

Previously, the system used `window.open(printUrl, "_blank")` to display the printable invoice, requiring users to manually print from the new tab. This disrupted the workflow.

The new implementation:
- Fetches the rendered print HTML from the `/printview` endpoint.
- Injects it into a hidden iframe.
- Triggers the browser’s native print dialog (`window.print()`) directly.
- Automatically marks the invoice as printed via `frappe.client.set_value`.
- Updates local state to reflect the print action without page reloads.

---

## Benefits
- Seamless in-app printing flow (no new tab or context switch).  
- Compatible with kiosk and thermal printer setups.  
- Preserves ERPNext print format rendering.  
- Cleaner user experience, especially for touch-based POS systems.

---

