### PR TITLE
fix: fixes incorrect field reference in POS profile lookup

### DIFF
--- a/ury/ury/doctype/ury_kot/ury_kot.py
+++ b/ury/ury/doctype/ury_kot/ury_kot.py
@@ -132,7 +132,7 @@ class URYKOT(Document):
     def get_auto_manufacture_setting(self):
         """Fetch Auto Manufacture on Sale flag from POS Profile"""
         pos_profile = frappe.db.get_value(
-            "URY Production Unit", self.name, "pos_profile"
+            "URY Production Unit", self.production, "pos_profile"
         )
         return frappe.db.get_value(
             "POS Profile", pos_profile, "auto_manufacture_on_sale"


### PR DESCRIPTION
Updates the lookup to use the correct production unit field when fetching the POS profile, ensuring accurate retrieval of settings for auto manufacture on sale.