### PR TITLE
feat(pos): add retry logic and improved closing UI

### DIFF
--- a/pos/src/components/POSClosingDialog.tsx
+++ b/pos/src/components/POSClosingDialog.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import CurrencyInput from "react-currency-input-field";
-import { X, FileText, Loader2, Users } from "lucide-react";
+import { X, FileText, Loader2, AlertTriangle, CheckCircle2, XCircle, RefreshCw } from "lucide-react";
 import { Dialog, DialogContent, Button } from "./ui";
 import { call } from "../lib/frappe-sdk";
 import { checkPOSOpening } from "../lib/pos-opening-api";
@@ -11,11 +11,18 @@ interface POSClosingDialogProps {
   user: any;
 }
 
+type ProcessingStage = 'idle' | 'closing' | 'success' | 'error'
+
 const POSClosingDialog: React.FC<POSClosingDialogProps> = ({ onClose, user }) => {
   const [isProcessing, setIsProcessing] = useState(false);
+  const [processingStage, setProcessingStage] = useState<ProcessingStage>('idle');
   const [openingEntry, setOpeningEntry] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [summary, setSummary] = useState<any | null>(null);
+  const [hasFailedClosing, setHasFailedClosing] = useState(false);
+  const [failedClosingEntry, setFailedClosingEntry] = useState<string | null>(null);
+  const [failedClosingError, setFailedClosingError] = useState<string | null>(null);
+
   const currencySymbol = getCurrencySymbol();
 
   useEffect(() => {
@@ -35,6 +42,13 @@ const POSClosingDialog: React.FC<POSClosingDialogProps> = ({ onClose, user }) =>
         });
 
         if (res.message) {
+          // Check if there's a failed closing entry
+          if (res.message.has_failed_closing) {
+            setHasFailedClosing(true);
+            setFailedClosingEntry(res.message.failed_closing_entry);
+            setFailedClosingError(res.message.error_message);
+          }
+
           setSummary(res.message);
         }
       } catch (err) {
@@ -46,33 +60,98 @@ const POSClosingDialog: React.FC<POSClosingDialogProps> = ({ onClose, user }) =>
     fetchData();
   }, [user]);
 
-  const handleClosePOS = async () => {
+  const handleClosePOS = async (isRetry: boolean = false) => {
     setIsProcessing(true);
+    setProcessingStage('closing');
     setError(null);
+
     try {
-      const res = await call.post("ury.ury_pos.api.submit_pos_closing", {
-        pos_opening_entry: openingEntry,
-        closing_amounts: summary.payments.map((p: any) => ({
-          mode_of_payment: p.mode_of_payment,
-          closing_amount: p.closing_amount || 0,
-        }))
-      });
+      let res;
+
+      if (isRetry && failedClosingEntry) {
+        // Retry the existing failed closing entry
+        res = await call.post("ury.ury_pos.api.retry_pos_closing", {
+            closing_entry_name: failedClosingEntry,
+        });
+      } else {
+          res = await call.post("ury.ury_pos.api.submit_pos_closing", {
+            pos_opening_entry: openingEntry,
+            closing_amounts: summary.payments.map((p: any) => ({
+              mode_of_payment: p.mode_of_payment,
+              closing_amount: p.closing_amount || 0,
+          }))
+        });
+      }
 
       if (res.message?.status === "success") {
-        if ((window as any).showToast) {
-          (window as any).showToast.success("POS closed successfully");
-        }
-        window.location.reload();
-        onClose();
+        setIsProcessing('success');
+
+        setTimeout(() => {
+          if ((window as any).showToast) {
+            (window as any).showToast.success("POS closed successfully");
+          }
+          window.location.reload();
+        }, 5000);
+      } else if (res.message?.status === "failed") {
+        setProcessingStage('error');
+        setHasFailedClosing(true);
+        setFailedClosingEntry(res.message.failed_closing_entry);
+        setFailedClosingError(res.message.error_message);
+        setError(res.message.error_message || "Failed to close POS. Please contact your administrator.")
       } else {
-        setError(res.message?.message || "Failed to close POS.");
+        setProcessingStage('error');
+        setError(res.message?.message || "Failed to close POS. Please contact your administrator.");
       }
     } catch (err: any) {
       console.error("Error closing POS:", err);
-      setError("Failed to close POS.");
+      setProcessingStage('error');
+      const errorMsg = err?.exception || err?.message || "Failed to close POS. Please contact your administrator.";
+      setError(errorMsg);
     } finally {
       setIsProcessing(false);
     }
+  };
+
+  const renderProcessingOverlay = () => {
+    if (processingStage === 'idle') return null;
+
+    return (
+      <div className="absolute inset-0 bg-white/95 z-50 flex items-center justify-center">
+        <div className="text-center space-y-4 max-w-md px-6">
+          {processingStage === 'closing' && (
+            <>
+              <Loader2 className="w-16 h-16 animate-spin mx-auto text-blue-600" />
+              <h3 className="text-xl font-semibold">Closing POS...</h3>
+              <p className="text-gray-600">Please wait while we process the closing. This may take a moment.</p>
+            </>
+          )}
+          
+          {processingStage === 'success' && (
+            <>
+              <CheckCircle2 className="w-16 h-16 mx-auto text-green-600" />
+              <h3 className="text-xl font-semibold text-green-700">POS Closed Successfully!</h3>
+              <p className="text-gray-600">Redirecting...</p>
+            </>
+          )}
+          
+          {processingStage === 'error' && (
+            <>
+              <XCircle className="w-16 h-16 mx-auto text-red-600" />
+              <h3 className="text-xl font-semibold text-red-700">Closing Failed</h3>
+              <div className="text-sm text-gray-600 max-h-40 overflow-y-auto bg-red-50 p-3 rounded border border-red-200">
+                {error}
+              </div>
+              <Button 
+                onClick={() => setProcessingStage('idle')} 
+                className="mt-4"
+              >
+                Go Back
+              </Button>
+            </>
+          )}
+        </div>
+      </div>
+    );
   };
 
   return (
@@ -82,6 +161,9 @@ const POSClosingDialog: React.FC<POSClosingDialogProps> = ({ onClose, user }) =>
         className="bg-white w-full max-w-4xl max-h-[90vh] flex flex-col p-0"
         showCloseButton={false}
       >
+
+        {renderProcessingOverlay()}
+
         <div className="flex justify-between items-center p-4 border-b border-gray-200">
           <h2 className="text-2xl font-bold">Close POS</h2>
           <Button onClick={onClose} variant="ghost" size="icon">
@@ -90,17 +172,37 @@ const POSClosingDialog: React.FC<POSClosingDialogProps> = ({ onClose, user }) =>
         </div>
 
         <div className="flex-1 overflow-y-auto p-6 space-y-6">
-          {error && (
+          {error && !processingStage && (
             <div className="mb-6 p-4 bg-red-50 border-l-4 border-red-400 rounded-r-lg text-sm text-red-700">
               {error}
             </div>
           )}
 
+            {hasFailedClosing && (
+              <div className="mb-6 p-4 bg-yellow-50 border-l-4 border-yellow-400 rounded-r-lg">
+                <div className="flex items-start gap-3">
+                  <AlertTriangle className="w-5 h-5 text-yellow-600 mt-0.5 flex-shrink-0" />
+                  <div className="flex-1">
+                    <h4 className="font-semibold text-yellow-800 mb-1">Previous Closing Attempt Failed</h4>
+                    <p className="text-sm text-yellow-700 mb-3">
+                      A closing attempt failed. Here's what went wrong:
+                    </p>
+                    <div className="text-xs text-yellow-700 bg-yellow-100 p-3 rounded mb-3 max-h-32 overflow-y-auto">
+                      {failedClosingError}
+                    </div>
+                    <p className="text-sm text-yellow-700">
+                      You can retry the closing with updated amounts below.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            )}
+
             {/* Invoices */}
             {summary?.pos_transactions?.length > 0 && (
               <div className="space-y-3">
                 <h3 className="text-lg font-semibold mb-3 flex items-center gap-2">
-                  <FileText className="w-5 h-5" /> Invoices
+                  <FileText className="w-5 h-5" /> Invoices ({summary.pos_transactions.length})
                 </h3>
                 <ul className="divide-y border rounded-md">
                   {summary.pos_transactions.map((inv: any) => (
@@ -187,14 +289,14 @@ const POSClosingDialog: React.FC<POSClosingDialogProps> = ({ onClose, user }) =>
 
         <div className="p-4 border-t border-gray-200">
           <Button
-            onClick={handleClosePOS}
+            onClick={() => handleClosePOS(hasFailedClosing)}
             disabled={isProcessing || !openingEntry || !summary}
             className="w-full"
           >
             {isProcessing ? (
               <span className="flex items-center gap-2">
                 <Loader2 className="w-4 h-4 animate-spin" />
-                Closing...
+                {hasFailedClosing ? "Retrying..." : "Closing..."}
               </span>
             ) : !summary ? (
               <span className="flex items-center gap-2">
@@ -202,7 +304,10 @@ const POSClosingDialog: React.FC<POSClosingDialogProps> = ({ onClose, user }) =>
                 Loading summary...
               </span>
             ): (
-              "Confirm Close"
+              <span className="flex items-center gap-2">
+                {hasFailedClosing && <RefreshCw className="w-4 h-4" />}
+                {hasFailedClosing ? "Retry Closing" : "Confirm Close"}
+              </span>
             )}
           </Button>
         </div>

--- a/ury/ury_pos/api.py
+++ b/ury/ury_pos/api.py
@@ -2,13 +2,13 @@ from datetime import timedelta
 
 import frappe
 from erpnext.accounts.doctype.pos_closing_entry.pos_closing_entry import (
-    get_pos_invoices,
-    make_closing_entry_from_opening,
+	get_pos_invoices,
+	make_closing_entry_from_opening,
 )
 from erpnext.accounts.doctype.pos_invoice.pos_invoice import get_stock_availability
 from frappe import _
 from frappe.query_builder import DocType
-from frappe.utils import flt
+from frappe.utils import flt, get_datetime, now_datetime, strip_html_tags, time_diff_in_seconds
 
 UMI = DocType("URY Menu Item")
 IT = DocType("Item")
@@ -16,300 +16,273 @@ IT = DocType("Item")
 
 @frappe.whitelist()
 def getTable(room):
-    branch_name = getBranch()
-    tables = frappe.get_all(
-        "URY Table",
-        fields=[
-            "name",
-            "occupied",
-            "latest_invoice_time",
-            "is_take_away",
-            "restaurant_room",
-            "table_shape",
-        ],
-        filters={
-            "branch": branch_name,
-            "restaurant_room": room,
-        },
-    )
-    return tables
+	branch_name = getBranch()
+	tables = frappe.get_all(
+		"URY Table",
+		fields=[
+			"name",
+			"occupied",
+			"latest_invoice_time",
+			"is_take_away",
+			"restaurant_room",
+			"table_shape",
+		],
+		filters={
+			"branch": branch_name,
+			"restaurant_room": room,
+		},
+	)
+	return tables
 
 
 @frappe.whitelist()
 def getRestaurantMenu(pos_profile, room=None, order_type=None):
-    """
-    Retrieves the restaurant menu items based on the provided POS profile, room, and order type.
+	"""
+	Retrieves the restaurant menu items based on the provided POS profile, room, and order type.
 
-    This function determines the appropriate menu for a restaurant by considering the user's role,
-    the POS profile, the selected room, and the order type. It fetches menu items, checks their
-    availability (including stock levels and QSR item groups), and filters out unavailable items
-    if specified in the POS profile settings.
+	This function determines the appropriate menu for a restaurant by considering the user's role,
+	the POS profile, the selected room, and the order type. It fetches menu items, checks their
+	availability (including stock levels and QSR item groups), and filters out unavailable items
+	if specified in the POS profile settings.
 
-    Args:
-        pos_profile (str): The name of the POS Profile to use for menu selection.
-        room (str, optional): The room identifier to fetch a room-specific menu. Defaults to None.
-        order_type (str, optional): The order type (e.g., dine-in, takeaway) to fetch an order-type-specific menu. Defaults to None.
+	Args:
+	    pos_profile (str): The name of the POS Profile to use for menu selection.
+	    room (str, optional): The room identifier to fetch a room-specific menu. Defaults to None.
+	    order_type (str, optional): The order type (e.g., dine-in, takeaway) to fetch an order-type-specific menu. Defaults to None.
 
-    Returns:
-        dict: A dictionary containing:
-            - "items": A list of menu items with their details and stock availability.
-            - "modified_time": The last modified timestamp of the menu.
-            - "name": The name of the selected menu.
+	Returns:
+	    dict: A dictionary containing:
+	        - "items": A list of menu items with their details and stock availability.
+	        - "modified_time": The last modified timestamp of the menu.
+	        - "name": The name of the selected menu.
 
-    Raises:
-        frappe.ValidationError: If no active menu is set for the restaurant.
-    """
-    menu_items = []
-    user_role = frappe.get_roles()
-    pos_profile_doc = frappe.get_doc("POS Profile", pos_profile)
+	Raises:
+	    frappe.ValidationError: If no active menu is set for the restaurant.
+	"""
+	menu_items = []
+	user_role = frappe.get_roles()
+	pos_profile_doc = frappe.get_doc("POS Profile", pos_profile)
 
-    cashier = any(
-        role.role in user_role for role in pos_profile_doc.role_allowed_for_billing
-    )
-    branch_name = getBranch()
-    restaurant = frappe.db.get_value("URY Restaurant", {"branch": branch_name}, "name")
+	cashier = any(role.role in user_role for role in pos_profile_doc.role_allowed_for_billing)
+	branch_name = getBranch()
+	restaurant = frappe.db.get_value("URY Restaurant", {"branch": branch_name}, "name")
 
-    if cashier and order_type:
-        order_type_wise_menu = frappe.db.get_value(
-            "URY Restaurant", restaurant, "order_type_wise_menu"
-        )
+	if cashier and order_type:
+		order_type_wise_menu = frappe.db.get_value("URY Restaurant", restaurant, "order_type_wise_menu")
 
-        if order_type_wise_menu:
-            menu = frappe.db.get_value(
-                "Order Type Menu",
-                {"parent": restaurant, "order_type": order_type},
-                "menu",
-            )
-            if not menu:
-                menu = frappe.db.get_value("URY Restaurant", restaurant, "active_menu")
+		if order_type_wise_menu:
+			menu = frappe.db.get_value(
+				"Order Type Menu",
+				{"parent": restaurant, "order_type": order_type},
+				"menu",
+			)
+			if not menu:
+				menu = frappe.db.get_value("URY Restaurant", restaurant, "active_menu")
 
-        else:
-            menu = frappe.db.get_value("URY Restaurant", restaurant, "active_menu")
+		else:
+			menu = frappe.db.get_value("URY Restaurant", restaurant, "active_menu")
 
-    elif room:
-        room_wise_menu = frappe.db.get_value(
-            "URY Restaurant", restaurant, "room_wise_menu"
-        )
+	elif room:
+		room_wise_menu = frappe.db.get_value("URY Restaurant", restaurant, "room_wise_menu")
 
-        if room_wise_menu:
-            menu = frappe.db.get_value(
-                "Menu for Room", {"parent": restaurant, "room": room}, "menu"
-            )
-            if not menu:
-                menu = frappe.db.get_value("URY Restaurant", restaurant, "active_menu")
-        else:
-            menu = frappe.db.get_value("URY Restaurant", restaurant, "active_menu")
+		if room_wise_menu:
+			menu = frappe.db.get_value("Menu for Room", {"parent": restaurant, "room": room}, "menu")
+			if not menu:
+				menu = frappe.db.get_value("URY Restaurant", restaurant, "active_menu")
+		else:
+			menu = frappe.db.get_value("URY Restaurant", restaurant, "active_menu")
 
-    # Default menu if nothing is selected
-    else:
-        menu = frappe.db.get_value("URY Restaurant", restaurant, "active_menu")
+	# Default menu if nothing is selected
+	else:
+		menu = frappe.db.get_value("URY Restaurant", restaurant, "active_menu")
 
-    if not menu:
-        frappe.throw(
-            _("Please set an active menu for Restaurant {0}").format(restaurant)
-        )
+	if not menu:
+		frappe.throw(_("Please set an active menu for Restaurant {0}").format(restaurant))
 
-    # Get QSR item groups for this POS Profile
-    qsr_item_groups = get_qsr_item_groups(pos_profile)
+	# Get QSR item groups for this POS Profile
+	qsr_item_groups = get_qsr_item_groups(pos_profile)
 
-    menu_items_query = (
-        frappe.qb.from_(UMI)
-        .join(IT)
-        .on(UMI.item == IT.name)
-        .select(
-            UMI.item,
-            UMI.item_name,
-            UMI.rate,
-            UMI.special_dish,
-            UMI.disabled,
-            UMI.course,
-            IT.image.as_("item_image"),
-            IT.item_code.as_("item_code"),
-            IT.default_bom,
-            IT.item_group,
-        )
-        .where(UMI.parent == menu)
-        .where(UMI.disabled == 0)
-        .where(IT.disabled == 0)
-    )
+	menu_items_query = (
+		frappe.qb.from_(UMI)
+		.join(IT)
+		.on(UMI.item == IT.name)
+		.select(
+			UMI.item,
+			UMI.item_name,
+			UMI.rate,
+			UMI.special_dish,
+			UMI.disabled,
+			UMI.course,
+			IT.image.as_("item_image"),
+			IT.item_code.as_("item_code"),
+			IT.default_bom,
+			IT.item_group,
+		)
+		.where(UMI.parent == menu)
+		.where(UMI.disabled == 0)
+		.where(IT.disabled == 0)
+	)
 
-    menu_items = menu_items_query.run(as_dict=True)
+	menu_items = menu_items_query.run(as_dict=True)
 
-    menu_items_with_stock_count = []
-    for item in menu_items:
-        # Check if item belongs to QSR item groups
-        if item.item_group in qsr_item_groups:
-            stock_balance = "QSR"
-        else:
-            # Check stock only if item does not have a BOM
-            stock_balance = get_stock_availability(
-                item.item_code, pos_profile_doc.warehouse
-            )[0]
+	menu_items_with_stock_count = []
+	for item in menu_items:
+		# Check if item belongs to QSR item groups
+		if item.item_group in qsr_item_groups:
+			stock_balance = "QSR"
+		else:
+			# Check stock only if item does not have a BOM
+			stock_balance = get_stock_availability(item.item_code, pos_profile_doc.warehouse)[0]
 
-        menu_items_with_stock_count.append(
-            {
-                "item": item.item,
-                "item_name": item.item_name,
-                "rate": item.rate,
-                "special_dish": item.special_dish,
-                "disabled": item.disabled,
-                "item_image": item.item_image,
-                "course": item.course,
-                "stock_balance": stock_balance,
-            }
-        )
+		menu_items_with_stock_count.append(
+			{
+				"item": item.item,
+				"item_name": item.item_name,
+				"rate": item.rate,
+				"special_dish": item.special_dish,
+				"disabled": item.disabled,
+				"item_image": item.item_image,
+				"course": item.course,
+				"stock_balance": stock_balance,
+			}
+		)
 
-    filtered_menu_items = []
+	filtered_menu_items = []
 
-    # if pos_profile.hide_unavailable_items hide items with zero stock
-    if pos_profile_doc.hide_unavailable_items:
-        # Filter out items with zero stock, but keep QSR items
-        filtered_menu_items = [
-            item
-            for item in menu_items_with_stock_count
-            if item["stock_balance"] == "QSR"
-            or item["stock_balance"] is None
-            or item["stock_balance"] > 0
-        ]
-    else:
-        filtered_menu_items = menu_items_with_stock_count
+	# if pos_profile.hide_unavailable_items hide items with zero stock
+	if pos_profile_doc.hide_unavailable_items:
+		# Filter out items with zero stock, but keep QSR items
+		filtered_menu_items = [
+			item
+			for item in menu_items_with_stock_count
+			if item["stock_balance"] == "QSR" or item["stock_balance"] is None or item["stock_balance"] > 0
+		]
+	else:
+		filtered_menu_items = menu_items_with_stock_count
 
-    modified = frappe.db.get_value("URY Menu", menu, "modified")
+	modified = frappe.db.get_value("URY Menu", menu, "modified")
 
-    return {"items": filtered_menu_items, "modified_time": modified, "name": menu}
+	return {"items": filtered_menu_items, "modified_time": modified, "name": menu}
 
 
 def get_qsr_item_groups(pos_profile):
-    """
-    Get all item groups linked to the URY Production Unit assigned to this POS Profile.
-    """
-    production_unit = frappe.db.get_value(
-        "URY Production Unit", {"pos_profile": pos_profile}, "name"
-    )
+	"""
+	Get all item groups linked to the URY Production Unit assigned to this POS Profile.
+	"""
+	production_unit = frappe.db.get_value("URY Production Unit", {"pos_profile": pos_profile}, "name")
 
-    if not production_unit:
-        return []
+	if not production_unit:
+		return []
 
-    return frappe.get_all(
-        "URY Production Item Groups",
-        filters={"parent": production_unit},
-        pluck="item_group",
-    )
+	return frappe.get_all(
+		"URY Production Item Groups",
+		filters={"parent": production_unit},
+		pluck="item_group",
+	)
 
 
 @frappe.whitelist()
 def getBranch():
-    user = frappe.session.user
-    if user != "Administrator":
-        sql_query = """
+	user = frappe.session.user
+	if user != "Administrator":
+		sql_query = """
             SELECT b.branch
             FROM `tabURY User` AS a
             INNER JOIN `tabBranch` AS b ON a.parent = b.name
             WHERE a.user = %s
         """
-        branch_array = frappe.db.sql(sql_query, user, as_dict=True)
-        if not branch_array:
-            frappe.throw("User is not Associated with any Branch.Please refresh Page")
+		branch_array = frappe.db.sql(sql_query, user, as_dict=True)
+		if not branch_array:
+			frappe.throw("User is not Associated with any Branch.Please refresh Page")
 
-        branch_name = branch_array[0].get("branch")
+		branch_name = branch_array[0].get("branch")
 
-        return branch_name
+		return branch_name
 
 
 @frappe.whitelist()
 def getBranchRoom():
-    user = frappe.session.user
-    if user != "Administrator":
-        return [
-            {
-                "name": None,
-                "branch": None,
-            }
-        ]
+	user = frappe.session.user
+	if user != "Administrator":
+		return [
+			{
+				"name": None,
+				"branch": None,
+			}
+		]
 
-    sql_query = """
+	sql_query = """
         SELECT b.branch , a.room
         FROM `tabURY User` AS a
         INNER JOIN `tabBranch` AS b ON a.parent = b.name
         WHERE a.user = %s
     """
 
-    branch_array = frappe.db.sql(sql_query, user, as_dict=True)
+	branch_array = frappe.db.sql(sql_query, user, as_dict=True)
 
-    if not branch_array:
-        frappe.throw(
-            "User is not linked to any branch. Please contact your administrator."
-        )
+	if not branch_array:
+		frappe.throw("User is not linked to any branch. Please contact your administrator.")
 
-    branch_name = branch_array[0].get("branch")
-    room_name = branch_array[0].get("room")
+	branch_name = branch_array[0].get("branch")
+	room_name = branch_array[0].get("room")
 
-    if not branch_name:
-        frappe.throw(
-            "Branch information is missing for the user. Please contact your administrator."
-        )
+	if not branch_name:
+		frappe.throw("Branch information is missing for the user. Please contact your administrator.")
 
-    if not room_name:
-        frappe.throw(
-            "No room assigned to this user. Please contact your administrator."
-        )
+	if not room_name:
+		frappe.throw("No room assigned to this user. Please contact your administrator.")
 
-    return [
-        {
-            "name": room_name,
-            "branch": branch_name,
-        }
-    ]
+	return [
+		{
+			"name": room_name,
+			"branch": branch_name,
+		}
+	]
 
 
 @frappe.whitelist()
 def getRoom():
-    user = frappe.session.user
-    if user != "Administrator":
-        sql_query = """
+	user = frappe.session.user
+	if user != "Administrator":
+		sql_query = """
             SELECT b.branch, a.room
             FROM `tabURY User` AS a
             INNER JOIN `tabBranch` AS b ON a.parent = b.name
             WHERE a.user = %s
         """
-        branch_array = frappe.db.sql(sql_query, user, as_dict=True)
+		branch_array = frappe.db.sql(sql_query, user, as_dict=True)
 
-        if not branch_array:
-            frappe.throw(
-                "No branch or room information found for the user. Please contact your administrator."
-            )
+		if not branch_array:
+			frappe.throw(
+				"No branch or room information found for the user. Please contact your administrator."
+			)
 
-        room_details = [
-            {"name": row.get("room"), "branch": row.get("branch")}
-            for row in branch_array
-        ]
+		room_details = [{"name": row.get("room"), "branch": row.get("branch")} for row in branch_array]
 
-        return room_details
+		return room_details
 
 
 @frappe.whitelist()
 def getModeOfPayment():
-    posDetails = getPosProfile()
-    posProfile = posDetails["pos_profile"]
-    posProfiles = frappe.get_doc("POS Profile", posProfile)
-    mode_of_payments = posProfiles.payments
-    modeOfPayments = []
-    for mop in mode_of_payments:
-        modeOfPayments.append(
-            {"mode_of_payment": mop.mode_of_payment, "opening_amount": float(0)}
-        )
-    return modeOfPayments
+	posDetails = getPosProfile()
+	posProfile = posDetails["pos_profile"]
+	posProfiles = frappe.get_doc("POS Profile", posProfile)
+	mode_of_payments = posProfiles.payments
+	modeOfPayments = []
+	for mop in mode_of_payments:
+		modeOfPayments.append({"mode_of_payment": mop.mode_of_payment, "opening_amount": float(0)})
+	return modeOfPayments
 
 
 @frappe.whitelist()
 def getInvoiceForCashier(status, cashier, limit, limit_start):
-    branch = getBranch()
-    updatedlist = []
-    limit = int(limit) + 1
-    limit_start = int(limit_start)
-    if status == "Draft":
-        invoices = frappe.db.sql(
-            """
+	branch = getBranch()
+	updatedlist = []
+	limit = int(limit) + 1
+	limit_start = int(limit_start)
+	if status == "Draft":
+		invoices = frappe.db.sql(
+			"""
             SELECT
                 pi.name, pi.invoice_printed, pi.grand_total, pi.restaurant_table,
                 pi.cashier, u.full_name as cashier_name, pi.waiter, pi.net_total, pi.posting_time,
@@ -322,14 +295,14 @@ def getInvoiceForCashier(status, cashier, limit, limit_start):
             ORDER BY pi.modified desc
             LIMIT %s OFFSET %s
             """,
-            (branch, status, cashier, limit, limit_start),
-            as_dict=True,
-        )
-        updatedlist.extend(invoices)
-    elif status == "Unbilled":
-        docstatus = "Draft"
-        invoices = frappe.db.sql(
-            """
+			(branch, status, cashier, limit, limit_start),
+			as_dict=True,
+		)
+		updatedlist.extend(invoices)
+	elif status == "Unbilled":
+		docstatus = "Draft"
+		invoices = frappe.db.sql(
+			"""
             SELECT
                 pi.name, pi.invoice_printed, pi.grand_total, pi.restaurant_table,
                 pi.cashier, u.full_name as cashier_name, pi.waiter, pi.net_total, pi.posting_time,
@@ -342,14 +315,14 @@ def getInvoiceForCashier(status, cashier, limit, limit_start):
             ORDER BY pi.modified desc
             LIMIT %s OFFSET %s
             """,
-            (branch, docstatus, cashier, limit, limit_start),
-            as_dict=True,
-        )
-        updatedlist.extend(invoices)
-    elif status == "Recently Paid":
-        docstatus = "Paid"
-        invoices = frappe.db.sql(
-            """
+			(branch, docstatus, cashier, limit, limit_start),
+			as_dict=True,
+		)
+		updatedlist.extend(invoices)
+	elif status == "Recently Paid":
+		docstatus = "Paid"
+		invoices = frappe.db.sql(
+			"""
             SELECT
                 pi.name, pi.invoice_printed, pi.grand_total, pi.restaurant_table,
                 pi.cashier, u.full_name as cashier_name, pi.waiter, pi.net_total, pi.posting_time,
@@ -361,13 +334,13 @@ def getInvoiceForCashier(status, cashier, limit, limit_start):
             ORDER BY pi.modified desc
             LIMIT %s OFFSET %s
             """,
-            (branch, docstatus, cashier, limit, limit_start),
-            as_dict=True,
-        )
-        updatedlist.extend(invoices)
-    else:
-        invoices = frappe.db.sql(
-            """
+			(branch, docstatus, cashier, limit, limit_start),
+			as_dict=True,
+		)
+		updatedlist.extend(invoices)
+	else:
+		invoices = frappe.db.sql(
+			"""
             SELECT
                 pi.name, pi.invoice_printed, pi.grand_total, pi.restaurant_table,
                 pi.cashier, u.full_name as cashier_name, pi.waiter, pi.net_total, pi.posting_time,
@@ -379,28 +352,28 @@ def getInvoiceForCashier(status, cashier, limit, limit_start):
             ORDER BY pi.modified desc
             LIMIT %s OFFSET %s
             """,
-            (branch, status, cashier, limit, limit_start),
-            as_dict=True,
-        )
+			(branch, status, cashier, limit, limit_start),
+			as_dict=True,
+		)
 
-        updatedlist.extend(invoices)
-    if len(updatedlist) == limit and status != "Recently Paid":
-        next = True
-        updatedlist.pop()
-    else:
-        next = False
-    return {"data": updatedlist, "next": next}
+		updatedlist.extend(invoices)
+	if len(updatedlist) == limit and status != "Recently Paid":
+		next = True
+		updatedlist.pop()
+	else:
+		next = False
+	return {"data": updatedlist, "next": next}
 
 
 @frappe.whitelist()
 def getPosInvoice(status, limit, limit_start):
-    branch = getBranch()
-    updatedlist = []
-    limit = int(limit) + 1
-    limit_start = int(limit_start)
-    if status == "Draft":
-        invoices = frappe.db.sql(
-            """
+	branch = getBranch()
+	updatedlist = []
+	limit = int(limit) + 1
+	limit_start = int(limit_start)
+	if status == "Draft":
+		invoices = frappe.db.sql(
+			"""
             SELECT
                 pi.name, pi.invoice_printed, pi.grand_total, pi.restaurant_table,
                 pi.cashier, u.full_name as cashier_name, pi.waiter, pi.net_total, pi.posting_time,
@@ -413,14 +386,14 @@ def getPosInvoice(status, limit, limit_start):
             ORDER BY pi.modified desc
             LIMIT %s OFFSET %s
             """,
-            (branch, status, limit, limit_start),
-            as_dict=True,
-        )
-        updatedlist.extend(invoices)
-    elif status == "Unbilled":
-        docstatus = "Draft"
-        invoices = frappe.db.sql(
-            """
+			(branch, status, limit, limit_start),
+			as_dict=True,
+		)
+		updatedlist.extend(invoices)
+	elif status == "Unbilled":
+		docstatus = "Draft"
+		invoices = frappe.db.sql(
+			"""
             SELECT
                 pi.name, pi.invoice_printed, pi.grand_total, pi.restaurant_table,
                 pi.cashier, u.full_name as cashier_name, pi.waiter, pi.net_total, pi.posting_time,
@@ -433,14 +406,14 @@ def getPosInvoice(status, limit, limit_start):
             ORDER BY pi.modified desc
             LIMIT %s OFFSET %s
             """,
-            (branch, docstatus, limit, limit_start),
-            as_dict=True,
-        )
-        updatedlist.extend(invoices)
-    elif status == "Recently Paid":
-        docstatus = "Paid"
-        invoices = frappe.db.sql(
-            """
+			(branch, docstatus, limit, limit_start),
+			as_dict=True,
+		)
+		updatedlist.extend(invoices)
+	elif status == "Recently Paid":
+		docstatus = "Paid"
+		invoices = frappe.db.sql(
+			"""
             SELECT
                 pi.name, pi.invoice_printed, pi.grand_total, pi.restaurant_table,
                 pi.cashier, u.full_name as cashier_name, pi.waiter, pi.net_total, pi.posting_time,
@@ -452,13 +425,13 @@ def getPosInvoice(status, limit, limit_start):
             ORDER BY pi.modified desc
             LIMIT %s OFFSET %s
             """,
-            (branch, docstatus, limit, limit_start),
-            as_dict=True,
-        )
-        updatedlist.extend(invoices)
-    else:
-        invoices = frappe.db.sql(
-            """
+			(branch, docstatus, limit, limit_start),
+			as_dict=True,
+		)
+		updatedlist.extend(invoices)
+	else:
+		invoices = frappe.db.sql(
+			"""
             SELECT
                 pi.name, pi.invoice_printed, pi.grand_total, pi.restaurant_table,
                 pi.cashier, u.full_name as cashier_name, pi.waiter, pi.net_total, pi.posting_time,
@@ -470,40 +443,40 @@ def getPosInvoice(status, limit, limit_start):
             ORDER BY pi.modified desc
             LIMIT %s OFFSET %s
             """,
-            (branch, status, limit, limit_start),
-            as_dict=True,
-        )
+			(branch, status, limit, limit_start),
+			as_dict=True,
+		)
 
-        updatedlist.extend(invoices)
-    if len(updatedlist) == limit and status != "Recently Paid":
-        next = True
-        updatedlist.pop()
-    else:
-        next = False
-    return {"data": updatedlist, "next": next}
+		updatedlist.extend(invoices)
+	if len(updatedlist) == limit and status != "Recently Paid":
+		next = True
+		updatedlist.pop()
+	else:
+		next = False
+	return {"data": updatedlist, "next": next}
 
 
 @frappe.whitelist()
 def searchPosInvoice(query, status):
-    if not query:
-        return {"data": [], "next": False}
-    query = query.lower()
+	if not query:
+		return {"data": [], "next": False}
+	query = query.lower()
 
-    # Build the WHERE clause based on status
-    status_condition = ""
-    if status == "Recently Paid":
-        status_condition = "pi.status = 'Paid'"
-    elif status == "Unbilled":
-        status_condition = """pi.status = 'Draft'
+	# Build the WHERE clause based on status
+	status_condition = ""
+	if status == "Recently Paid":
+		status_condition = "pi.status = 'Paid'"
+	elif status == "Unbilled":
+		status_condition = """pi.status = 'Draft'
         AND pi.restaurant_table IS NOT NULL
         AND pi.restaurant_table != ''
         AND pi.invoice_printed = 0"""
-    else:
-        status_condition = f"pi.status = '{status}'"
+	else:
+		status_condition = f"pi.status = '{status}'"
 
-    # Use SQL query to get orders with cashier full name
-    pos_invoices = frappe.db.sql(
-        f"""
+	# Use SQL query to get orders with cashier full name
+	pos_invoices = frappe.db.sql(
+		f"""
         SELECT
             pi.name, pi.customer, pi.grand_total, pi.posting_date, pi.posting_time,
             pi.order_type, pi.restaurant_table, pi.status, pi.rounded_total,
@@ -519,50 +492,46 @@ def searchPosInvoice(query, status):
         ORDER BY pi.modified desc
         LIMIT 10
         """,
-        (f"%{query}%", f"%{query}%", f"%{query}%"),
-        as_dict=True,
-    )
+		(f"%{query}%", f"%{query}%", f"%{query}%"),
+		as_dict=True,
+	)
 
-    return {"data": pos_invoices, "next": len(pos_invoices) == 10}
+	return {"data": pos_invoices, "next": len(pos_invoices) == 10}
 
 
 @frappe.whitelist()
 def get_select_field_options():
-    options = frappe.get_meta("POS Invoice").get_field("order_type").options
-    if options:
-        return [{"name": option} for option in options.split("\n")]
-    else:
-        return []
+	options = frappe.get_meta("POS Invoice").get_field("order_type").options
+	if options:
+		return [{"name": option} for option in options.split("\n")]
+	else:
+		return []
 
 
 @frappe.whitelist()
 def fav_items(customer):
-    pos_invoices = frappe.get_all(
-        "POS Invoice", filters={"customer": customer}, fields=["name"]
-    )
-    item_qty = {}
+	pos_invoices = frappe.get_all("POS Invoice", filters={"customer": customer}, fields=["name"])
+	item_qty = {}
 
-    for invoice in pos_invoices:
-        pos_invoice = frappe.get_doc("POS Invoice", invoice.name)
-        for item in pos_invoice.items:
-            item_name = item.item_name
-            qty = item.qty
-            if item_name not in item_qty:
-                item_qty[item_name] = 0
-            item_qty[item_name] += qty
+	for invoice in pos_invoices:
+		pos_invoice = frappe.get_doc("POS Invoice", invoice.name)
+		for item in pos_invoice.items:
+			item_name = item.item_name
+			qty = item.qty
+			if item_name not in item_qty:
+				item_qty[item_name] = 0
+			item_qty[item_name] += qty
 
-    favorite_items = [
-        {"item_name": item_name, "qty": qty} for item_name, qty in item_qty.items()
-    ]
-    return favorite_items
+	favorite_items = [{"item_name": item_name, "qty": qty} for item_name, qty in item_qty.items()]
+	return favorite_items
 
 
 @frappe.whitelist()
 def getCashier(room):
-    branch = getBranch()
-    cashier = None
-    pos_opening_list = frappe.db.sql(
-        """
+	branch = getBranch()
+	cashier = None
+	pos_opening_list = frappe.db.sql(
+		"""
         SELECT DISTINCT `tabPOS Opening Entry`.name
         FROM `tabPOS Opening Entry`
         INNER JOIN `tabMultiple Rooms`
@@ -572,52 +541,52 @@ def getCashier(room):
         AND `tabPOS Opening Entry`.docstatus = 1
         AND `tabMultiple Rooms`.room = %s
     """,
-        (branch, room),
-        as_dict=True,
-    )
-    if pos_opening_list:
-        cashier = frappe.db.get_value(
-            "POS Opening Entry",
-            {"name": pos_opening_list[0].name},
-            "user",
-        )
-    return cashier
+		(branch, room),
+		as_dict=True,
+	)
+	if pos_opening_list:
+		cashier = frappe.db.get_value(
+			"POS Opening Entry",
+			{"name": pos_opening_list[0].name},
+			"user",
+		)
+	return cashier
 
 
 @frappe.whitelist()
 def getPosProfile():
-    branchName = getBranch()
-    waiter = frappe.session.user
-    bill_present = False
-    qz_host = None
-    printer = None
-    cashier = None
-    owner = None
-    posProfile = frappe.db.exists("POS Profile", {"branch": branchName})
-    pos_profiles = frappe.get_doc("POS Profile", posProfile)
-    global_defaults = frappe.get_single("Global Defaults")
-    disable_rounded_total = global_defaults.disable_rounded_total
+	branchName = getBranch()
+	waiter = frappe.session.user
+	bill_present = False
+	qz_host = None
+	printer = None
+	cashier = None
+	owner = None
+	posProfile = frappe.db.exists("POS Profile", {"branch": branchName})
+	pos_profiles = frappe.get_doc("POS Profile", posProfile)
+	global_defaults = frappe.get_single("Global Defaults")
+	disable_rounded_total = global_defaults.disable_rounded_total
 
-    if pos_profiles.branch == branchName:
-        pos_profile_name = pos_profiles.name
-        warehouse = pos_profiles.warehouse
-        branch = pos_profiles.branch
-        company = pos_profiles.company
-        tableAttention = pos_profiles.table_attention_time
-        get_cashier = frappe.get_doc("POS Profile", pos_profile_name)
-        print_format = pos_profiles.print_format
-        paid_limit = pos_profiles.paid_limit
-        enable_discount = pos_profiles.custom_enable_discount
-        multiple_cashier = pos_profiles.custom_enable_multiple_cashier
-        edit_order_type = pos_profiles.custom_edit_order_type
-        enable_kot_reprint = pos_profiles.custom_enable_kot_reprint
-        if multiple_cashier:
-            details = getBranchRoom()
-            room = details[0].get("name")
-            branch = details[0].get("branch")
+	if pos_profiles.branch == branchName:
+		pos_profile_name = pos_profiles.name
+		warehouse = pos_profiles.warehouse
+		branch = pos_profiles.branch
+		company = pos_profiles.company
+		tableAttention = pos_profiles.table_attention_time
+		get_cashier = frappe.get_doc("POS Profile", pos_profile_name)
+		print_format = pos_profiles.print_format
+		paid_limit = pos_profiles.paid_limit
+		enable_discount = pos_profiles.custom_enable_discount
+		multiple_cashier = pos_profiles.custom_enable_multiple_cashier
+		edit_order_type = pos_profiles.custom_edit_order_type
+		enable_kot_reprint = pos_profiles.custom_enable_kot_reprint
+		if multiple_cashier:
+			details = getBranchRoom()
+			room = details[0].get("name")
+			branch = details[0].get("branch")
 
-            pos_opening_list = frappe.db.sql(
-                """
+			pos_opening_list = frappe.db.sql(
+				"""
                 SELECT DISTINCT `tabPOS Opening Entry`.name
                 FROM `tabPOS Opening Entry`
                 INNER JOIN `tabMultiple Rooms`
@@ -627,225 +596,219 @@ def getPosProfile():
                 AND `tabPOS Opening Entry`.docstatus = 1
                 AND `tabMultiple Rooms`.room = %s
             """,
-                (branch, room),
-                as_dict=True,
-            )
-            if pos_opening_list:
-                pos_opened_cashier = frappe.db.get_value(
-                    "POS Opening Entry",
-                    {"name": pos_opening_list[0].name},
-                    "user",
-                )
-            else:
-                pos_opened_cashier = None
-            for user_details in get_cashier.applicable_for_users:
-                if user_details.custom_main_cashier:
-                    owner = user_details.user
+				(branch, room),
+				as_dict=True,
+			)
+			if pos_opening_list:
+				pos_opened_cashier = frappe.db.get_value(
+					"POS Opening Entry",
+					{"name": pos_opening_list[0].name},
+					"user",
+				)
+			else:
+				pos_opened_cashier = None
+			for user_details in get_cashier.applicable_for_users:
+				if user_details.custom_main_cashier:
+					owner = user_details.user
 
-                if frappe.session.user == owner:
-                    cashier = owner
-                else:
-                    cashier = pos_opened_cashier
+				if frappe.session.user == owner:
+					cashier = owner
+				else:
+					cashier = pos_opened_cashier
 
-        else:
-            cashier = get_cashier.applicable_for_users[0].user
-            owner = get_cashier.applicable_for_users[0].user
+		else:
+			cashier = get_cashier.applicable_for_users[0].user
+			owner = get_cashier.applicable_for_users[0].user
 
-        qz_print = pos_profiles.qz_print
-        print_type = None
+		qz_print = pos_profiles.qz_print
+		print_type = None
 
-        for pos_profile in pos_profiles.printer_settings:
-            if pos_profile.bill == 1:
-                printer = pos_profile.printer
-                bill_present = True
-                break
+		for pos_profile in pos_profiles.printer_settings:
+			if pos_profile.bill == 1:
+				printer = pos_profile.printer
+				bill_present = True
+				break
 
-        if qz_print == 1:
-            print_type = "qz"
-            qz_host = pos_profiles.qz_host
+		if qz_print == 1:
+			print_type = "qz"
+			qz_host = pos_profiles.qz_host
 
-        elif bill_present:
-            print_type = "network"
+		elif bill_present:
+			print_type = "network"
 
-        else:
-            print_type = "socket"
+		else:
+			print_type = "socket"
 
-    invoice_details = {
-        "pos_profile": pos_profile_name,
-        "branch": branch,
-        "company": company,
-        "waiter": waiter,
-        "warehouse": warehouse,
-        "cashier": cashier,
-        "print_format": print_format,
-        "qz_print": qz_print,
-        "qz_host": qz_host,
-        "printer": printer,
-        "print_type": print_type,
-        "tableAttention": tableAttention,
-        "paid_limit": paid_limit,
-        "disable_rounded_total": disable_rounded_total,
-        "enable_discount": enable_discount,
-        "multiple_cashier": multiple_cashier,
-        "owner": owner,
-        "edit_order_type": edit_order_type,
-        "enable_kot_reprint": enable_kot_reprint,
-    }
+	invoice_details = {
+		"pos_profile": pos_profile_name,
+		"branch": branch,
+		"company": company,
+		"waiter": waiter,
+		"warehouse": warehouse,
+		"cashier": cashier,
+		"print_format": print_format,
+		"qz_print": qz_print,
+		"qz_host": qz_host,
+		"printer": printer,
+		"print_type": print_type,
+		"tableAttention": tableAttention,
+		"paid_limit": paid_limit,
+		"disable_rounded_total": disable_rounded_total,
+		"enable_discount": enable_discount,
+		"multiple_cashier": multiple_cashier,
+		"owner": owner,
+		"edit_order_type": edit_order_type,
+		"enable_kot_reprint": enable_kot_reprint,
+	}
 
-    return invoice_details
+	return invoice_details
 
 
 @frappe.whitelist()
 def getPosInvoiceItems(invoice):
-    itemDetails = []
-    taxDetails = []
-    orderdItems = frappe.get_doc("POS Invoice", invoice)
-    posItems = orderdItems.items
-    for items in posItems:
-        item_name = items.item_name
-        qty = items.qty
-        amount = items.rate
-        itemDetails.append(
-            {
-                "item_name": item_name,
-                "qty": qty,
-                "amount": amount,
-            }
-        )
-    taxDetail = orderdItems.taxes
-    for tax in taxDetail:
-        description = tax.description
-        rate = tax.tax_amount
-        taxDetails.append(
-            {
-                "description": description,
-                "rate": rate,
-            }
-        )
-    return itemDetails, taxDetails
+	itemDetails = []
+	taxDetails = []
+	orderdItems = frappe.get_doc("POS Invoice", invoice)
+	posItems = orderdItems.items
+	for items in posItems:
+		item_name = items.item_name
+		qty = items.qty
+		amount = items.rate
+		itemDetails.append(
+			{
+				"item_name": item_name,
+				"qty": qty,
+				"amount": amount,
+			}
+		)
+	taxDetail = orderdItems.taxes
+	for tax in taxDetail:
+		description = tax.description
+		rate = tax.tax_amount
+		taxDetails.append(
+			{
+				"description": description,
+				"rate": rate,
+			}
+		)
+	return itemDetails, taxDetails
 
 
 @frappe.whitelist()
 def posOpening():
-    branchName = getBranch()
-    pos_opening_list = frappe.get_all(
-        "POS Opening Entry",
-        fields=["name", "docstatus", "status", "posting_date"],
-        filters={
-            "branch": branchName,
-            "status": "Open",
-            "docstatus": 1,
-            "user": frappe.session.user,
-        },
-    )
-    if not pos_opening_list:
-        return {"status": "not_opened", "opening_entry": None}
+	branchName = getBranch()
+	pos_opening_list = frappe.get_all(
+		"POS Opening Entry",
+		fields=["name", "docstatus", "status", "posting_date"],
+		filters={
+			"branch": branchName,
+			"status": "Open",
+			"docstatus": 1,
+			"user": frappe.session.user,
+		},
+	)
+	if not pos_opening_list:
+		return {"status": "not_opened", "opening_entry": None}
 
-    return {"status": "open", "opening_entry": pos_opening_list[0].name}
+	return {"status": "open", "opening_entry": pos_opening_list[0].name}
 
 
 @frappe.whitelist()
 def getAggregator():
-    branchName = getBranch()
-    aggregatorList = frappe.get_all(
-        "Aggregator Settings",
-        fields=["customer"],
-        filters={"parent": branchName, "parenttype": "Branch"},
-    )
-    return aggregatorList
+	branchName = getBranch()
+	aggregatorList = frappe.get_all(
+		"Aggregator Settings",
+		fields=["customer"],
+		filters={"parent": branchName, "parenttype": "Branch"},
+	)
+	return aggregatorList
 
 
 @frappe.whitelist()
 def getAggregatorItem(aggregator):
-    branchName = getBranch()
-    aggregatorItem = []
-    aggregatorItemList = []
-    priceList = frappe.db.get_value(
-        "Aggregator Settings",
-        {"customer": aggregator, "parent": branchName, "parenttype": "Branch"},
-        "price_list",
-    )
-    aggregatorItem = frappe.get_all(
-        "Item Price",
-        fields=["item_code", "item_name", "price_list_rate"],
-        filters={"selling": 1, "price_list": priceList},
-    )
-    aggregatorItemList = [
-        {
-            "item": item.item_code,
-            "item_name": item.item_name,
-            "rate": item.price_list_rate,
-            "item_image": frappe.db.get_value("Item", item.item, "image"),
-        }
-        for item in aggregatorItem
-        if not frappe.db.get_value("Item", item.item_code, "disabled")
-    ]
-    return aggregatorItemList
+	branchName = getBranch()
+	aggregatorItem = []
+	aggregatorItemList = []
+	priceList = frappe.db.get_value(
+		"Aggregator Settings",
+		{"customer": aggregator, "parent": branchName, "parenttype": "Branch"},
+		"price_list",
+	)
+	aggregatorItem = frappe.get_all(
+		"Item Price",
+		fields=["item_code", "item_name", "price_list_rate"],
+		filters={"selling": 1, "price_list": priceList},
+	)
+	aggregatorItemList = [
+		{
+			"item": item.item_code,
+			"item_name": item.item_name,
+			"rate": item.price_list_rate,
+			"item_image": frappe.db.get_value("Item", item.item, "image"),
+		}
+		for item in aggregatorItem
+		if not frappe.db.get_value("Item", item.item_code, "disabled")
+	]
+	return aggregatorItemList
 
 
 @frappe.whitelist()
 def getAggregatorMOP(aggregator):
-    branchName = getBranch()
+	branchName = getBranch()
 
-    modeOfPayment = frappe.db.get_value(
-        "Aggregator Settings",
-        {"customer": aggregator, "parent": branchName, "parenttype": "Branch"},
-        "mode_of_payments",
-    )
-    modeOfPaymentsList = []
-    modeOfPaymentsList.append(
-        {"mode_of_payment": modeOfPayment, "opening_amount": float(0)}
-    )
-    return modeOfPaymentsList
+	modeOfPayment = frappe.db.get_value(
+		"Aggregator Settings",
+		{"customer": aggregator, "parent": branchName, "parenttype": "Branch"},
+		"mode_of_payments",
+	)
+	modeOfPaymentsList = []
+	modeOfPaymentsList.append({"mode_of_payment": modeOfPayment, "opening_amount": float(0)})
+	return modeOfPaymentsList
 
 
 @frappe.whitelist()
 def validate_pos_close(pos_profile):
-    enable_unclosed_pos_check = frappe.db.get_value(
-        "POS Profile", pos_profile, "custom_daily_pos_close"
-    )
+	enable_unclosed_pos_check = frappe.db.get_value("POS Profile", pos_profile, "custom_daily_pos_close")
 
-    if enable_unclosed_pos_check:
-        current_datetime = frappe.utils.now_datetime()
-        start_of_day = current_datetime.replace(
-            hour=5, minute=0, second=0, microsecond=0
-        )
+	if enable_unclosed_pos_check:
+		current_datetime = frappe.utils.now_datetime()
+		start_of_day = current_datetime.replace(hour=5, minute=0, second=0, microsecond=0)
 
-        if current_datetime > start_of_day:
-            previous_day = start_of_day - timedelta(days=1)
+		if current_datetime > start_of_day:
+			previous_day = start_of_day - timedelta(days=1)
 
-        else:
-            previous_day = start_of_day
+		else:
+			previous_day = start_of_day
 
-        unclosed_pos_opening = frappe.db.exists(
-            "POS Opening Entry",
-            {
-                "posting_date": previous_day.date(),
-                "status": "Open",
-                "pos_profile": pos_profile,
-                "docstatus": 1,
-                "user": frappe.session.user,
-            },
-        )
+		unclosed_pos_opening = frappe.db.exists(
+			"POS Opening Entry",
+			{
+				"posting_date": previous_day.date(),
+				"status": "Open",
+				"pos_profile": pos_profile,
+				"docstatus": 1,
+				"user": frappe.session.user,
+			},
+		)
 
-        if unclosed_pos_opening:
-            return "Failed"
+		if unclosed_pos_opening:
+			return "Failed"
 
-        return "Success"
+		return "Success"
 
-    return "Success"
+	return "Success"
 
 
 @frappe.whitelist()
 def getAllOrders(limit, limit_start):
-    """Fetch all orders that are either Draft or Draft with Dine In order type"""
-    branch = getBranch()
-    updatedlist = []
-    limit = int(limit) + 1
-    limit_start = int(limit_start)
+	"""Fetch all orders that are either Draft or Draft with Dine In order type"""
+	branch = getBranch()
+	updatedlist = []
+	limit = int(limit) + 1
+	limit_start = int(limit_start)
 
-    invoices = frappe.db.sql(
-        """
+	invoices = frappe.db.sql(
+		"""
         SELECT
             pi.name, pi.invoice_printed, pi.grand_total, pi.restaurant_table,
             pi.cashier, pi.waiter, u.full_name as waiter_name, pi.net_total, pi.posting_time,
@@ -862,99 +825,183 @@ def getAllOrders(limit, limit_start):
         ORDER BY pi.modified desc
         LIMIT %s OFFSET %s
         """,
-        (branch, limit, limit_start),
-        as_dict=True,
-    )
-    updatedlist.extend(invoices)
+		(branch, limit, limit_start),
+		as_dict=True,
+	)
+	updatedlist.extend(invoices)
 
-    if len(updatedlist) == limit:
-        next = True
-        updatedlist.pop()
-    else:
-        next = False
+	if len(updatedlist) == limit:
+		next = True
+		updatedlist.pop()
+	else:
+		next = False
 
-    return {"data": updatedlist, "next": next}
+	return {"data": updatedlist, "next": next}
 
 
 @frappe.whitelist()
 def create_opening_voucher(company: str, pos_profile: str, balance_details: list):
-    try:
-        new_pos_opening = frappe.get_doc(
-            {
-                "doctype": "POS Opening Entry",
-                "period_start_date": frappe.utils.get_datetime(),
-                "posting_date": frappe.utils.getdate(),
-                "user": frappe.session.user,
-                "pos_profile": pos_profile,
-                "company": company,
-            }
-        )
-        new_pos_opening.set("balance_details", balance_details)
-        new_pos_opening.submit()
+	try:
+		new_pos_opening = frappe.get_doc(
+			{
+				"doctype": "POS Opening Entry",
+				"period_start_date": frappe.utils.get_datetime(),
+				"posting_date": frappe.utils.getdate(),
+				"user": frappe.session.user,
+				"pos_profile": pos_profile,
+				"company": company,
+			}
+		)
+		new_pos_opening.set("balance_details", balance_details)
+		new_pos_opening.submit()
 
-        return {"status": "success", "opening_entry": new_pos_opening.name}
-    except Exception as e:
-        frappe.log_error(frappe.get_traceback(), "POS Opening Creation Failed")
-        return {"status": "error", "message": str(e)}
+		return {"status": "success", "opening_entry": new_pos_opening.name}
+	except Exception as e:
+		frappe.log_error(frappe.get_traceback(), "POS Opening Creation Failed")
+		return {"status": "error", "message": str(e)}
 
 
 @frappe.whitelist()
 def get_closing_preview(pos_opening_entry: str):
-    """Return a preview summary for the dialog (doesn't save anything)."""
-    opening_entry = frappe.get_doc("POS Opening Entry", pos_opening_entry)
-    closing_entry = make_closing_entry_from_opening(opening_entry)
+	"""Return a preview summary for the dialog (doesn't save anything)."""
+	opening_entry = frappe.get_doc("POS Opening Entry", pos_opening_entry)
 
-    # waiter summary
-    invoices = get_pos_invoices(
-        closing_entry.period_start_date,
-        closing_entry.period_end_date,
-        closing_entry.pos_profile,
-        closing_entry.user,
-    )
-    waiter_map = {}
-    for inv in invoices:
-        waiter = inv.get("owner") or "Unassigned"
-        if waiter not in waiter_map:
-            waiter_map[waiter] = {"waiter": waiter, "total": 0.0, "invoices": 0}
-        waiter_map[waiter]["invoices"] += 1
-        waiter_map[waiter]["total"] += flt(inv.get("grand_total") or 0.0)
+	existing_closing = check_existing_closing_entry(pos_opening_entry)
+	if existing_closing:
+		return existing_closing
 
-    waiter_summary = list(waiter_map.values())
-    # Convert child tables on the closing_entry into serializable dicts
-    payment_reconciliation = [p.as_dict() for p in closing_entry.payment_reconciliation]
-    taxes = [t.as_dict() for t in closing_entry.taxes]
-    pos_transactions = [p.as_dict() for p in closing_entry.pos_transactions]
+	closing_entry = make_closing_entry_from_opening(opening_entry)
 
-    return {
-        "grand_total": closing_entry.grand_total,
-        "net_total": closing_entry.net_total,
-        "total_quantity": closing_entry.total_quantity,
-        "taxes": taxes,
-        "payments": payment_reconciliation,
-        "pos_transactions": pos_transactions,
-        "waiter_summary": waiter_summary,
-    }
+	# waiter summary
+	invoices = get_pos_invoices(
+		closing_entry.period_start_date,
+		closing_entry.period_end_date,
+		closing_entry.pos_profile,
+		closing_entry.user,
+	)
+	waiter_map = {}
+	for inv in invoices:
+		waiter = inv.get("owner") or "Unassigned"
+		if waiter not in waiter_map:
+			waiter_map[waiter] = {"waiter": waiter, "total": 0.0, "invoices": 0}
+		waiter_map[waiter]["invoices"] += 1
+		waiter_map[waiter]["total"] += flt(inv.get("grand_total") or 0.0)
+
+	waiter_summary = list(waiter_map.values())
+	# Convert child tables on the closing_entry into serializable dicts
+	payment_reconciliation = [p.as_dict() for p in closing_entry.payment_reconciliation]
+	taxes = [t.as_dict() for t in closing_entry.taxes]
+	pos_transactions = [p.as_dict() for p in closing_entry.pos_transactions]
+
+	return {
+		"grand_total": closing_entry.grand_total,
+		"net_total": closing_entry.net_total,
+		"total_quantity": closing_entry.total_quantity,
+		"taxes": taxes,
+		"payments": payment_reconciliation,
+		"pos_transactions": pos_transactions,
+		"waiter_summary": waiter_summary,
+	}
+
+
+def check_existing_closing_entry(pos_opening_entry: str):
+	"""Check if there's a recent failed closing entry."""
+	# Look for draft closing entries for this opening entry
+	existing = frappe.get_all(
+		"POS Closing Entry",
+		filters={
+			"pos_opening_entry": pos_opening_entry,
+			"status": ["in", ["Failed", "Draft"]],
+		},
+		fields=["name", "modified", "creation", "docstatus", "error_message"],
+		order_by="modified desc",
+		limit=1,
+	)
+
+	if not existing:
+		return None
+
+	entry = existing[0]
+	modified_time = get_datetime(entry.modified)
+	current_time = now_datetime()
+	time_diff = time_diff_in_seconds(current_time, modified_time)
+
+	# If modified within last 30 minutes, consider it a recent failure
+	if time_diff < 1800:
+		closing_doc = frappe.get_doc("POS Closing Entry", entry.name)
+
+		error_message = strip_html_tags(entry.error_message)
+
+		return {
+			"has_failed_closing": True,
+			"failed_closing_entry": entry.name,
+			"error_message": error_message,
+			"modified": entry.modified,
+			"grand_total": closing_doc.grand_total,
+			"net_total": closing_doc.net_total,
+			"total_quantity": closing_doc.total_quantity,
+			"taxes": [t.as_dict() for t in closing_doc.taxes],
+			"payments": [p.as_dict() for p in closing_doc.payment_reconciliation],
+			"pos_transactions": [p.as_dict() for p in closing_doc.pos_transactions],
+		}
 
 
 @frappe.whitelist()
-def submit_pos_closing(pos_opening_entry: str, closing_amounts: list = None):
-    """Actually create & submit a POS Closing Entry."""
-    try:
-        opening_entry = frappe.get_doc("POS Opening Entry", pos_opening_entry)
-        closing_entry = make_closing_entry_from_opening(opening_entry)
+def retry_pos_closing(closing_entry_name: str):
+	"""Retry submitting an existing failed closing entry using ERPNext's built-in retry."""
+	try:
+		closing_entry = frappe.get_doc("POS Closing Entry", closing_entry_name)
 
-        # inject actual amounts
-        if closing_amounts:
-            closing_map = {
-                p["mode_of_payment"]: p["closing_amount"] for p in closing_amounts
-            }
-            for row in closing_entry.payment_reconciliation:
-                row.closing_amount = closing_map.get(row.mode_of_payment, 0)
-                row.difference = row.closing_amount - row.expected_amount
+		if closing_entry.status != "Failed":
+			return {"status": "error", "message": "This closing entry is not in failed status"}
 
-        closing_entry.insert(ignore_permissions=True)
-        closing_entry.submit()
-        return {"status": "success", "closing_entry": closing_entry.name}
-    except Exception as e:
-        frappe.log_error(frappe.get_traceback(), "POS Closing Failed")
-        return {"status": "error", "message": str(e)}
+		closing_entry.retry()
+
+		return {"status": "success", "closing_entry": closing_entry.name}
+
+	except Exception as e:
+		error_msg = str(e)
+		frappe.log_error("POS Closing Retry Failed", frappe.get_traceback())
+		return {"status": "error", "message": error_msg}
+
+
+@frappe.whitelist()
+def submit_pos_closing(pos_opening_entry: str, closing_amounts: list | None = None):
+	"""Actually create & submit a POS Closing Entry."""
+	try:
+		existing_closing = check_existing_closing_entry(pos_opening_entry)
+		if existing_closing:
+			return existing_closing
+
+		opening_entry = frappe.get_doc("POS Opening Entry", pos_opening_entry)
+		closing_entry = make_closing_entry_from_opening(opening_entry)
+
+		# inject actual amounts
+		if closing_amounts:
+			closing_map = {p["mode_of_payment"]: p["closing_amount"] for p in closing_amounts}
+			for row in closing_entry.payment_reconciliation:
+				row.closing_amount = closing_map.get(row.mode_of_payment, 0)
+				row.difference = row.closing_amount - row.expected_amount
+
+		closing_entry.insert(ignore_permissions=True)
+
+		frappe.db.commit()
+
+		try:
+			closing_entry.submit()
+		except Exception:
+			frappe.db.commit()
+			closing_entry.reload()
+
+			return {
+				"status": "failed",
+				"has_failed_closing": True,
+				"failed_closing_entry": closing_entry.name,
+				"error_message": strip_html_tags(closing_entry.error_message)
+				or strip_html_tags(frappe.get_traceback()),
+			}
+
+		return {"status": "success", "closing_entry": closing_entry.name}
+	except Exception as e:
+		frappe.log_error("POS Closing Failed", frappe.get_traceback())
+		return {"status": "error", "message": str(e)}


### PR DESCRIPTION
## Problem

- **Duplicate Records**: Users could trigger multiple `POS Closing Entry` entries even though the previous attempt failed or is still being processed in the backgound.
- **Poor Visibility**: Users had no feedback during consolidation process, which made it possible for them to retry closing pos due to the lack of progress on what was happening in the background

## Solution

This PR introduces a `Check-then-Create` pattern for POS Closings and a state-managed frontend overlay.

### Backend Changes:
- Modified POS closing to check for existing draft/failed entries before creation to prevent duplicate records.
- Added manual DB commits to ensure "Failed" status and error messages persist during stock validation errors.
- Updated the API to return existing failed entries directly to the frontend for immediate retries.

### Frontend Changes:
- Added a processing overlay with 'idle', 'closing', 'success', and 'error' stages.
- Implemented a full-screen overlay to prevent double-clicking and provide real-time feedback.
- Integrated "Retry" logic to allow users to resubmit failed closings without refreshing the page.
- Added descriptive error handling to display Negative Stock and other validation errors directly to the user.


https://github.com/user-attachments/assets/406975bd-3e2c-440b-8486-901df1526115

