### PR TITLE
fix: add stock cache invalidation for Stock Ledger Entry

### DIFF
--- a/ury/hooks.py
+++ b/ury/hooks.py
@@ -148,6 +148,9 @@ doc_events = {
 	"URY Menu Course": {
 		"validate": "ury.ury.api.ury_menu_course_validation.validate_priority",
 	},
+    "Stock Ledger Entry": {
+        "before_submit": "ury.ury_pos.api.invalidate_item_stock_cache"
+	}
 }
 
 # Scheduled Tasks

--- a/ury/ury_pos/api.py
+++ b/ury/ury_pos/api.py
@@ -169,6 +169,15 @@ def clear_all_pos_cache():
     frappe.cache().delete_keys("item_stock:")
     return True
 
+def invalidate_item_stock_cache(doc, method=None):
+    """
+    Triggered by Stock Ledger Entry (SLE).
+    Covers ALL stock-changing transactions in ERPNext.
+    """
+    if doc.item_code and doc.warehouse:
+        stock_key = f"item_stock:{doc.warehouse}:{doc.item_code}"
+        frappe.cache().delete_value(stock_key)
+
 
 def get_qsr_item_groups(pos_profile):
 	"""


### PR DESCRIPTION
Ensures item stock cache is cleared whenever stock ledger entries are submitted, preventing stale inventory data after stock changes.

Addresses cache consistency for all stock-affecting transactions.