### PR TITLE
fix(sync_order): correct item price retrieval in error message

### DIFF
--- a/ury/ury/doctype/ury_order/ury_order.py
+++ b/ury/ury/doctype/ury_order/ury_order.py
@@ -276,7 +276,7 @@ def sync_order(
             frappe.throw(
                 _(
                     "No item price found for Item: {0} in Price List: {1}. Please check the price list settings."
-                ).format(item.item_code, price_list)
+                ).format(d.get("item"), price_list)
             )
 
         else:


### PR DESCRIPTION
Updated the error message in the sync_order function to use the correct key for item retrieval. The previous implementation referenced an undefined variable, which led to confusion when no item price is found in the price list. This change ensures that the error message accurately reflects the item code being checked.